### PR TITLE
Add heavy metal-themed iPad Pro dashboard

### DIFF
--- a/Sources/WritersApp/Views/MetalDashboardView.swift
+++ b/Sources/WritersApp/Views/MetalDashboardView.swift
@@ -1,0 +1,674 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+// MARK: - Metal Dashboard View
+
+/// The main iPad Pro dashboard — a brutal, heavy metal-themed command center
+/// for your writing life. Inspired by Whitechapel and Lamb of God.
+///
+/// Sections:
+/// - **The Mantra** — rotating metal-inspired motivational quote
+/// - **Kill Count** — total words, documents, streaks, focus time
+/// - **The Armory** — quick-start focus sessions (Pomodoro, Sprint, Deep Work)
+/// - **War Room** — recent documents
+/// - **The Gauntlet** — writing goals and progress
+/// - **The Forge** — quick actions: new doc, browse templates
+@available(iOS 16.0, macOS 13.0, *)
+public struct MetalDashboardView: View {
+    @StateObject private var viewModel: MetalDashboardViewModel
+
+    public init(viewModel: MetalDashboardViewModel = MetalDashboardViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(spacing: 24) {
+                // Header
+                dashboardHeader
+
+                // Mantra banner
+                mantraBanner
+
+                // Kill Count stats row
+                killCountSection
+
+                // Two-column layout for middle sections
+                HStack(alignment: .top, spacing: 20) {
+                    // Left column
+                    VStack(spacing: 20) {
+                        armorySection
+                        gauntletSection
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    // Right column
+                    VStack(spacing: 20) {
+                        warRoomSection
+                        forgeSection
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(24)
+        }
+        .background(MetalTheme.abyssGradient.ignoresSafeArea())
+        .onAppear {
+            viewModel.loadDashboard()
+        }
+    }
+
+    // MARK: - Dashboard Header
+
+    private var dashboardHeader: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("WRITERS APP")
+                    .font(.system(size: 28, weight: .black, design: .default))
+                    .tracking(4)
+                    .foregroundColor(MetalTheme.chrome)
+
+                Text("iPad Pro Dashboard")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(MetalTheme.steel)
+            }
+
+            Spacer()
+
+            // Current focus session badge
+            if let session = viewModel.currentFocusSession, session.state == .active {
+                activeFocusBadge(session: session)
+            }
+        }
+    }
+
+    private func activeFocusBadge(session: FocusSession) -> some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(MetalTheme.crimson)
+                .frame(width: 8, height: 8)
+
+            Text(session.type.displayName.uppercased())
+                .font(.system(size: 11, weight: .heavy))
+                .tracking(1.5)
+                .foregroundColor(MetalTheme.ember)
+
+            if session.targetDuration > 0 {
+                Text(viewModel.formatTimeRemaining(session.timeRemaining))
+                    .font(.system(size: 13, weight: .bold, design: .monospaced))
+                    .foregroundColor(MetalTheme.chrome)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(MetalTheme.gunmetal)
+        .cornerRadius(20)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(MetalTheme.crimson.opacity(0.6), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Mantra Banner
+
+    private var mantraBanner: some View {
+        VStack(spacing: 10) {
+            Text("\u{201C}\(viewModel.currentMantra.quote)\u{201D}")
+                .font(.system(size: 16, weight: .medium, design: .serif))
+                .italic()
+                .foregroundColor(MetalTheme.chrome)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+
+            Text("- \(viewModel.currentMantra.attribution)")
+                .font(.system(size: 11, weight: .bold))
+                .tracking(1.5)
+                .foregroundColor(MetalTheme.bloodRed)
+        }
+        .padding(.vertical, 20)
+        .padding(.horizontal, 32)
+        .frame(maxWidth: .infinity)
+        .background(MetalTheme.obsidian)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(MetalTheme.bloodRed.opacity(0.3), lineWidth: 1)
+        )
+        .onTapGesture {
+            viewModel.refreshMantra()
+        }
+    }
+
+    // MARK: - Kill Count (Stats)
+
+    private var killCountSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            MetalTheme.sectionTitle("Kill Count")
+
+            HStack(spacing: 0) {
+                killCountStat(
+                    value: "\(viewModel.totalWords)",
+                    label: "Total Words",
+                    icon: "textformat.abc",
+                    accentColor: MetalTheme.crimson
+                )
+
+                killCountDivider
+
+                killCountStat(
+                    value: "\(viewModel.totalDocuments)",
+                    label: "Documents",
+                    icon: "doc.text.fill",
+                    accentColor: MetalTheme.ember
+                )
+
+                killCountDivider
+
+                killCountStat(
+                    value: streakDisplayValue,
+                    label: "Day Streak",
+                    icon: "flame.fill",
+                    accentColor: viewModel.writingStreak.isStreakActive ? MetalTheme.toxicGreen : MetalTheme.steel
+                )
+
+                killCountDivider
+
+                killCountStat(
+                    value: viewModel.formatDuration(viewModel.focusStats.totalFocusTime),
+                    label: "Focus Time",
+                    icon: "timer",
+                    accentColor: MetalTheme.gold
+                )
+
+                killCountDivider
+
+                killCountStat(
+                    value: "\(viewModel.focusStats.completedSessions)",
+                    label: "Sessions",
+                    icon: "checkmark.seal.fill",
+                    accentColor: MetalTheme.chrome
+                )
+            }
+            .metalCard()
+        }
+    }
+
+    private var streakDisplayValue: String {
+        let streak = viewModel.writingStreak
+        return "\(streak.currentStreak)"
+    }
+
+    private func killCountStat(value: String, label: String, icon: String, accentColor: Color) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundColor(accentColor)
+
+            Text(value)
+                .font(.system(size: 28, weight: .black, design: .rounded))
+                .foregroundColor(MetalTheme.chrome)
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+
+            Text(label.uppercased())
+                .font(.system(size: 9, weight: .bold))
+                .tracking(1.5)
+                .foregroundColor(MetalTheme.steel)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var killCountDivider: some View {
+        Rectangle()
+            .fill(MetalTheme.chainLink)
+            .frame(width: 1, height: 60)
+    }
+
+    // MARK: - The Armory (Focus Sessions)
+
+    private var armorySection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            MetalTheme.sectionTitle("The Armory")
+
+            VStack(spacing: 10) {
+                ForEach(FocusSessionType.allCases, id: \.self) { type in
+                    focusSessionButton(type: type)
+                }
+            }
+            .metalCard()
+
+            // Today's session summary
+            if viewModel.todayFocusStats.totalSessions > 0 {
+                todayFocusSummary
+            }
+        }
+    }
+
+    private func focusSessionButton(type: FocusSessionType) -> some View {
+        Button(action: { viewModel.startFocusSession(type: type) }) {
+            HStack(spacing: 12) {
+                Image(systemName: viewModel.iconForFocusType(type))
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(MetalTheme.ember)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(type.displayName)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(MetalTheme.chrome)
+
+                    if type.defaultDuration > 0 {
+                        Text(FocusSessionManager.formatDuration(type.defaultDuration))
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(MetalTheme.steel)
+                    } else {
+                        Text("No time limit")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(MetalTheme.steel)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "play.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(MetalTheme.crimson)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .background(MetalTheme.gunmetal)
+            .cornerRadius(8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var todayFocusSummary: some View {
+        HStack(spacing: 16) {
+            VStack(spacing: 2) {
+                Text("\(viewModel.todayFocusStats.totalSessions)")
+                    .font(.system(size: 20, weight: .black, design: .rounded))
+                    .foregroundColor(MetalTheme.chrome)
+                Text("SESSIONS")
+                    .font(.system(size: 8, weight: .bold))
+                    .tracking(1)
+                    .foregroundColor(MetalTheme.steel)
+            }
+
+            VStack(spacing: 2) {
+                Text("\(viewModel.todayFocusStats.totalWordsWritten)")
+                    .font(.system(size: 20, weight: .black, design: .rounded))
+                    .foregroundColor(MetalTheme.chrome)
+                Text("WORDS")
+                    .font(.system(size: 8, weight: .bold))
+                    .tracking(1)
+                    .foregroundColor(MetalTheme.steel)
+            }
+
+            VStack(spacing: 2) {
+                Text(viewModel.formatDuration(viewModel.todayFocusStats.totalFocusTime))
+                    .font(.system(size: 20, weight: .black, design: .rounded))
+                    .foregroundColor(MetalTheme.chrome)
+                Text("FOCUS")
+                    .font(.system(size: 8, weight: .bold))
+                    .tracking(1)
+                    .foregroundColor(MetalTheme.steel)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(MetalTheme.obsidian)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(MetalTheme.chainLink, lineWidth: 0.5)
+        )
+    }
+
+    // MARK: - War Room (Recent Documents)
+
+    private var warRoomSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                MetalTheme.sectionTitle("War Room")
+                Spacer()
+                Text("\(viewModel.recentDocuments.count) recent")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(MetalTheme.steel)
+            }
+
+            VStack(spacing: 8) {
+                if viewModel.recentDocuments.isEmpty {
+                    emptyWarRoom
+                } else {
+                    ForEach(viewModel.recentDocuments) { doc in
+                        documentRow(doc)
+                    }
+                }
+            }
+            .metalCard()
+        }
+    }
+
+    private var emptyWarRoom: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 28))
+                .foregroundColor(MetalTheme.chainLink)
+
+            Text("No documents yet")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(MetalTheme.steel)
+
+            Text("Hit The Forge to start writing")
+                .font(.system(size: 12))
+                .foregroundColor(MetalTheme.chainLink)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    private func documentRow(_ document: Document) -> some View {
+        Button(action: { viewModel.selectDocument(document) }) {
+            HStack(spacing: 12) {
+                // Category icon
+                Image(systemName: viewModel.iconForCategory(document.category))
+                    .font(.system(size: 14))
+                    .foregroundColor(MetalTheme.crimson)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(document.title)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(MetalTheme.chrome)
+                        .lineLimit(1)
+
+                    HStack(spacing: 8) {
+                        Text(document.category.rawValue)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(MetalTheme.steel)
+
+                        Text("\u{2022}")
+                            .foregroundColor(MetalTheme.chainLink)
+
+                        Text("\(document.wordCount) words")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(MetalTheme.steel)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(MetalTheme.chainLink)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .background(MetalTheme.gunmetal)
+            .cornerRadius(8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - The Gauntlet (Goals)
+
+    private var gauntletSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                MetalTheme.sectionTitle("The Gauntlet")
+                Spacer()
+
+                if viewModel.goalsSummary.achievedGoals > 0 {
+                    HStack(spacing: 4) {
+                        Image(systemName: "trophy.fill")
+                            .font(.system(size: 10))
+                            .foregroundColor(MetalTheme.gold)
+                        Text("\(viewModel.goalsSummary.achievedGoals) conquered")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundColor(MetalTheme.gold)
+                    }
+                }
+            }
+
+            VStack(spacing: 10) {
+                if viewModel.activeGoals.isEmpty {
+                    emptyGauntlet
+                } else {
+                    ForEach(viewModel.activeGoals) { goal in
+                        goalRow(goal)
+                    }
+                }
+
+                // Streak indicator
+                streakIndicator
+            }
+            .metalCard()
+        }
+    }
+
+    private var emptyGauntlet: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "target")
+                .font(.system(size: 28))
+                .foregroundColor(MetalTheme.chainLink)
+
+            Text("No active goals")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(MetalTheme.steel)
+
+            Text("Set a daily word count target to run the gauntlet")
+                .font(.system(size: 12))
+                .foregroundColor(MetalTheme.chainLink)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+    }
+
+    private func goalRow(_ goal: WritingGoal) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(goal.name)
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundColor(MetalTheme.chrome)
+
+                Spacer()
+
+                Text("\(goal.progressPercentage)%")
+                    .font(.system(size: 13, weight: .black, design: .rounded))
+                    .foregroundColor(goal.isAchieved ? MetalTheme.gold : MetalTheme.ember)
+            }
+
+            // Progress bar
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(MetalTheme.gunmetal)
+                        .frame(height: 8)
+
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(goal.isAchieved ? MetalTheme.conquestGradient : MetalTheme.forgeGradient)
+                        .frame(width: geo.size.width * goal.progress, height: 8)
+                }
+            }
+            .frame(height: 8)
+
+            HStack {
+                Text("\(goal.current) / \(goal.target) \(goal.unit.displayName.lowercased())")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(MetalTheme.steel)
+
+                Spacer()
+
+                if let days = goal.daysRemaining, days > 0 {
+                    Text("\(days)d remaining")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(MetalTheme.steel)
+                }
+            }
+        }
+        .padding(10)
+        .background(MetalTheme.gunmetal.opacity(0.5))
+        .cornerRadius(8)
+    }
+
+    private var streakIndicator: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 16))
+                .foregroundColor(
+                    viewModel.writingStreak.isStreakActive ? MetalTheme.ember : MetalTheme.chainLink
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                if viewModel.writingStreak.currentStreak > 0 {
+                    Text("\(viewModel.writingStreak.currentStreak)-day streak")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(MetalTheme.chrome)
+                } else {
+                    Text("No active streak")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(MetalTheme.steel)
+                }
+
+                if viewModel.writingStreak.longestStreak > 0 {
+                    Text("Longest: \(viewModel.writingStreak.longestStreak) days \u{2022} Total: \(viewModel.writingStreak.totalDaysWritten) days")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(MetalTheme.steel)
+                }
+            }
+
+            Spacer()
+
+            if viewModel.writingStreak.wroteToday {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(MetalTheme.toxicGreen)
+            }
+        }
+        .padding(10)
+        .background(MetalTheme.gunmetal.opacity(0.5))
+        .cornerRadius(8)
+    }
+
+    // MARK: - The Forge (Quick Actions)
+
+    private var forgeSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            MetalTheme.sectionTitle("The Forge")
+
+            VStack(spacing: 10) {
+                // New blank document
+                forgeActionButton(
+                    title: "New Blank Document",
+                    subtitle: "Start from nothing. Pure aggression.",
+                    icon: "doc.badge.plus",
+                    accentColor: MetalTheme.crimson,
+                    action: { viewModel.showNewDocumentSheet = true }
+                )
+
+                // Browse templates
+                forgeActionButton(
+                    title: "Browse Templates",
+                    subtitle: "\(viewModel.totalTemplates) templates ready to deploy",
+                    icon: "rectangle.stack.fill",
+                    accentColor: MetalTheme.ember,
+                    action: { viewModel.showTemplateSheet = true }
+                )
+
+                // Set a goal
+                forgeActionButton(
+                    title: "Set a Writing Goal",
+                    subtitle: "Run the gauntlet. Set your target.",
+                    icon: "target",
+                    accentColor: MetalTheme.gold,
+                    action: { viewModel.showGoalSheet = true }
+                )
+            }
+            .metalCard()
+
+            // Category breakdown
+            if !viewModel.documentsByCategory.isEmpty {
+                categoryBreakdown
+            }
+        }
+    }
+
+    private func forgeActionButton(title: String, subtitle: String, icon: String, accentColor: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(accentColor)
+                    .frame(width: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(MetalTheme.chrome)
+
+                    Text(subtitle)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(MetalTheme.steel)
+                }
+
+                Spacer()
+
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundColor(accentColor)
+            }
+            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .background(MetalTheme.gunmetal)
+            .cornerRadius(8)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var categoryBreakdown: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            let sortedCategories = viewModel.documentsByCategory.sorted { $0.value > $1.value }
+
+            ForEach(sortedCategories.prefix(5), id: \.key) { category, count in
+                HStack(spacing: 10) {
+                    Image(systemName: viewModel.iconForCategory(category))
+                        .font(.system(size: 12))
+                        .foregroundColor(MetalTheme.crimson)
+                        .frame(width: 20)
+
+                    Text(category.rawValue)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(MetalTheme.chrome)
+
+                    Spacer()
+
+                    Text("\(count)")
+                        .font(.system(size: 12, weight: .black, design: .rounded))
+                        .foregroundColor(MetalTheme.steel)
+                }
+            }
+        }
+        .padding(12)
+        .background(MetalTheme.obsidian)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(MetalTheme.chainLink, lineWidth: 0.5)
+        )
+    }
+}
+
+// MARK: - Preview
+
+@available(iOS 16.0, macOS 13.0, *)
+struct MetalDashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        MetalDashboardView()
+            .previewDevice("iPad Pro (12.9-inch) (6th generation)")
+            .previewInterfaceOrientation(.landscapeLeft)
+    }
+}
+
+#endif

--- a/Sources/WritersApp/Views/MetalDashboardViewModel.swift
+++ b/Sources/WritersApp/Views/MetalDashboardViewModel.swift
@@ -1,0 +1,214 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+// MARK: - Metal Dashboard View Model
+
+/// View model powering the heavy metal iPad Pro dashboard.
+/// Bridges WritersApp services into observable state for SwiftUI.
+@available(iOS 16.0, macOS 13.0, *)
+@MainActor
+public class MetalDashboardViewModel: ObservableObject {
+
+    // MARK: - Published State
+
+    // Stats
+    @Published public var totalDocuments: Int = 0
+    @Published public var totalWords: Int = 0
+    @Published public var totalTemplates: Int = 0
+    @Published public var averageWordCount: Int = 0
+    @Published public var documentsByCategory: [TemplateCategory: Int] = [:]
+
+    // Recent documents
+    @Published public var recentDocuments: [Document] = []
+
+    // Goals
+    @Published public var activeGoals: [WritingGoal] = []
+    @Published public var goalsSummary: GoalsSummary = GoalsSummary()
+    @Published public var writingStreak: WritingStreak = WritingStreak()
+
+    // Focus sessions
+    @Published public var currentFocusSession: FocusSession? = nil
+    @Published public var focusStats: FocusSessionStats = FocusSessionStats()
+    @Published public var todayFocusStats: FocusSessionStats = FocusSessionStats()
+
+    // Metal mantra
+    @Published public var currentMantra: MetalMantra = MetalMantra.random()
+
+    // Navigation / interaction state
+    @Published public var selectedDocument: Document? = nil
+    @Published public var showNewDocumentSheet: Bool = false
+    @Published public var showTemplateSheet: Bool = false
+    @Published public var showGoalSheet: Bool = false
+    @Published public var selectedFocusType: FocusSessionType? = nil
+
+    // MARK: - Services
+
+    private let app: WritersApp
+    private let focusSessionManager: FocusSessionManager
+    private let goalManager: WritingGoalManager
+
+    // MARK: - Init
+
+    public init(
+        app: WritersApp = WritersApp(),
+        focusSessionManager: FocusSessionManager = FocusSessionManager(),
+        goalManager: WritingGoalManager = WritingGoalManager()
+    ) {
+        self.app = app
+        self.focusSessionManager = focusSessionManager
+        self.goalManager = goalManager
+    }
+
+    // MARK: - Data Loading
+
+    /// Load all dashboard data from services
+    public func loadDashboard() {
+        loadStats()
+        loadRecentDocuments()
+        loadGoals()
+        loadFocusSessions()
+        refreshMantra()
+    }
+
+    public func loadStats() {
+        let stats = app.getStatistics()
+        totalDocuments = stats.totalDocuments
+        totalWords = stats.totalWordCount
+        averageWordCount = stats.averageWordCount
+        totalTemplates = stats.totalTemplates
+        documentsByCategory = stats.documentsByCategory
+    }
+
+    public func loadRecentDocuments() {
+        recentDocuments = app.documentManager.getRecentDocuments(limit: 6)
+    }
+
+    public func loadGoals() {
+        activeGoals = goalManager.getActiveGoals()
+        goalsSummary = goalManager.getSummary()
+        writingStreak = goalManager.getStreak()
+        goalManager.checkStreakStatus()
+    }
+
+    public func loadFocusSessions() {
+        currentFocusSession = focusSessionManager.getCurrentSession()
+        focusStats = focusSessionManager.getStats()
+        todayFocusStats = focusSessionManager.getTodayStats()
+    }
+
+    // MARK: - Document Actions
+
+    public func createBlankDocument(title: String, category: TemplateCategory) {
+        let doc = app.createBlankDocument(title: title, category: category)
+        selectedDocument = doc
+        loadStats()
+        loadRecentDocuments()
+    }
+
+    public func createFromTemplate(templateId: UUID, values: [String: String]) {
+        if let doc = app.createDocumentFromTemplate(templateId: templateId, values: values) {
+            selectedDocument = doc
+            loadStats()
+            loadRecentDocuments()
+        }
+    }
+
+    public func selectDocument(_ document: Document) {
+        app.documentManager.markDocumentOpened(id: document.id)
+        selectedDocument = document
+    }
+
+    public func getAllTemplates() -> [Template] {
+        return app.templateManager.getAllTemplates()
+    }
+
+    public func getTemplates(for category: TemplateCategory) -> [Template] {
+        return app.templateManager.getTemplates(for: category)
+    }
+
+    // MARK: - Focus Session Actions
+
+    public func startFocusSession(type: FocusSessionType, documentId: UUID? = nil) {
+        let wordCount = selectedDocument?.wordCount ?? 0
+        let session = focusSessionManager.startSession(
+            type: type,
+            documentId: documentId ?? selectedDocument?.id,
+            currentWordCount: wordCount
+        )
+        currentFocusSession = session
+        loadFocusSessions()
+    }
+
+    public func pauseFocusSession() {
+        currentFocusSession = focusSessionManager.pauseSession()
+    }
+
+    public func resumeFocusSession(pausedDuration: TimeInterval = 0) {
+        currentFocusSession = focusSessionManager.resumeSession(pausedDuration: pausedDuration)
+    }
+
+    public func endFocusSession(finalWordCount: Int? = nil) {
+        guard let session = currentFocusSession else { return }
+        let wordCount = finalWordCount ?? selectedDocument?.wordCount ?? session.wordsAtStart
+        _ = focusSessionManager.endSession(id: session.id, finalWordCount: wordCount)
+        currentFocusSession = nil
+        loadFocusSessions()
+    }
+
+    // MARK: - Goal Actions
+
+    public func createDailyGoal(target: Int) {
+        _ = goalManager.createDailyWordGoal(target: target)
+        loadGoals()
+    }
+
+    public func recordGoalProgress(goalId: UUID, amount: Int) {
+        _ = goalManager.recordProgress(goalId: goalId, amount: amount)
+        loadGoals()
+    }
+
+    // MARK: - Mantra
+
+    public func refreshMantra() {
+        currentMantra = MetalMantra.random()
+    }
+
+    // MARK: - Formatting Helpers
+
+    public func formatDuration(_ seconds: TimeInterval) -> String {
+        return FocusSessionManager.formatDuration(seconds)
+    }
+
+    public func formatTimeRemaining(_ seconds: TimeInterval) -> String {
+        return FocusSessionManager.formatTimeRemaining(seconds)
+    }
+
+    /// Category icon mapping with metal flair
+    public func iconForCategory(_ category: TemplateCategory) -> String {
+        switch category {
+        case .novel: return "book.closed.fill"
+        case .shortStory: return "text.book.closed.fill"
+        case .screenplay: return "film.fill"
+        case .blogPost: return "globe"
+        case .article: return "newspaper.fill"
+        case .essay: return "doc.text.fill"
+        case .poetry: return "quote.bubble.fill"
+        case .businessLetter: return "envelope.fill"
+        case .proposal: return "doc.badge.plus"
+        case .resume: return "person.text.rectangle.fill"
+        case .other: return "folder.fill"
+        }
+    }
+
+    /// Focus session type icon
+    public func iconForFocusType(_ type: FocusSessionType) -> String {
+        switch type {
+        case .freeWrite: return "flame.fill"
+        case .pomodoro: return "timer"
+        case .sprint: return "bolt.fill"
+        case .deepWork: return "moon.fill"
+        }
+    }
+}
+
+#endif

--- a/Sources/WritersApp/Views/MetalTheme.swift
+++ b/Sources/WritersApp/Views/MetalTheme.swift
@@ -1,0 +1,199 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+// MARK: - Heavy Metal Theme
+
+/// Brutal heavy metal color scheme and styling for the iPad Pro dashboard.
+/// Inspired by the darkness of Whitechapel and the raw aggression of Lamb of God.
+/// Pitch-black backgrounds, blood red accents, chrome text, ember highlights.
+@available(iOS 16.0, macOS 13.0, *)
+public enum MetalTheme {
+
+    // MARK: - Colors
+
+    /// Pitch-black background — the void before the breakdown
+    public static let abyss = Color(red: 0.03, green: 0.03, blue: 0.03)
+    /// Dark card/surface background
+    public static let obsidian = Color(red: 0.09, green: 0.09, blue: 0.09)
+    /// Slightly lighter surface for nested cards
+    public static let gunmetal = Color(red: 0.15, green: 0.15, blue: 0.15)
+    /// Blood red primary accent — the heart of the riff
+    public static let bloodRed = Color(red: 0.55, green: 0.0, blue: 0.0)
+    /// Crimson for highlights and active states
+    public static let crimson = Color(red: 0.86, green: 0.08, blue: 0.24)
+    /// Ember orange for warm highlights — like tube amps glowing
+    public static let ember = Color(red: 1.0, green: 0.27, blue: 0.0)
+    /// Chrome silver for primary text
+    public static let chrome = Color(red: 0.88, green: 0.88, blue: 0.88)
+    /// Dimmer silver for secondary text
+    public static let steel = Color(red: 0.55, green: 0.55, blue: 0.55)
+    /// Faint divider/border color
+    public static let chainLink = Color(red: 0.22, green: 0.22, blue: 0.22)
+    /// Gold for achievements and milestones
+    public static let gold = Color(red: 0.85, green: 0.65, blue: 0.13)
+    /// Sickly green for streak indicators
+    public static let toxicGreen = Color(red: 0.0, green: 0.75, blue: 0.25)
+
+    // MARK: - Gradients
+
+    /// Gradient for card accent bars — blood to fire
+    public static let fireGradient = LinearGradient(
+        colors: [bloodRed, crimson, ember],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    /// Subtle background gradient for the dashboard
+    public static let abyssGradient = LinearGradient(
+        colors: [abyss, Color(red: 0.05, green: 0.01, blue: 0.01)],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+
+    /// Progress bar gradient — forging progress
+    public static let forgeGradient = LinearGradient(
+        colors: [crimson, ember],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    /// Achievement/gold gradient
+    public static let conquestGradient = LinearGradient(
+        colors: [Color(red: 0.70, green: 0.50, blue: 0.05), gold, Color(red: 0.90, green: 0.75, blue: 0.20)],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    // MARK: - Typography Helpers
+
+    /// Section title — brutal uppercase with wide tracking
+    public static func sectionTitle(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 13, weight: .heavy, design: .default))
+            .tracking(3.0)
+            .foregroundColor(steel)
+    }
+
+    /// Card title
+    public static func cardTitle(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 18, weight: .bold, design: .default))
+            .foregroundColor(chrome)
+    }
+
+    /// Big stat number — the kill count
+    public static func statNumber(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 38, weight: .black, design: .rounded))
+            .foregroundColor(chrome)
+    }
+
+    /// Stat label under a number
+    public static func statLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 10, weight: .bold))
+            .tracking(2.0)
+            .foregroundColor(steel)
+    }
+}
+
+// MARK: - Metal Card Modifier
+
+@available(iOS 16.0, macOS 13.0, *)
+public struct MetalCardModifier: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .padding(16)
+            .background(MetalTheme.obsidian)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(MetalTheme.chainLink, lineWidth: 0.5)
+            )
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, *)
+extension View {
+    public func metalCard() -> some View {
+        modifier(MetalCardModifier())
+    }
+}
+
+// MARK: - Metal Mantras
+
+/// Brutal motivational quotes for writers who listen to the heavy stuff.
+public struct MetalMantra {
+    public let quote: String
+    public let attribution: String
+
+    public static let all: [MetalMantra] = [
+        // Deathcore / Whitechapel energy
+        MetalMantra(
+            quote: "The blank page is the silence before the breakdown. Fill it with violence.",
+            attribution: "Sawblade Syntax"
+        ),
+        MetalMantra(
+            quote: "You are the architect of your own devastation. Write it down.",
+            attribution: "The Somatic Defilement"
+        ),
+        MetalMantra(
+            quote: "Drop-tune your doubts. Let the low end carry you.",
+            attribution: "Seven-String Scripture"
+        ),
+        MetalMantra(
+            quote: "Every first draft is a pit. Throw yourself in.",
+            attribution: "Exile Protocol"
+        ),
+
+        // Groove metal / Lamb of God energy
+        MetalMantra(
+            quote: "Walk with me in hell — that's where the best stories live.",
+            attribution: "Ashes of the Wake"
+        ),
+        MetalMantra(
+            quote: "Now you've got something to write for.",
+            attribution: "Resolution Manifesto"
+        ),
+        MetalMantra(
+            quote: "Omerta: the code of silence ends when the pen hits paper.",
+            attribution: "The Sacrament of Ink"
+        ),
+        MetalMantra(
+            quote: "Laid to rest is what your excuses should be. Write.",
+            attribution: "Redneck Revision"
+        ),
+
+        // General brutal writing motivation
+        MetalMantra(
+            quote: "Writer's block is just the calm before the breakdown.",
+            attribution: "Riff & Revise"
+        ),
+        MetalMantra(
+            quote: "You don't find your voice. You distort it until it screams.",
+            attribution: "Gain Theory"
+        ),
+        MetalMantra(
+            quote: "Be relentless. Be loud. Be written.",
+            attribution: "Volume XI Press"
+        ),
+        MetalMantra(
+            quote: "The first draft is the soundcheck. The final draft is the wall of death.",
+            attribution: "Circle Pit Publishing"
+        ),
+        MetalMantra(
+            quote: "Through blast beats and black ink, manuscripts are forged.",
+            attribution: "Blacksmith's Quill"
+        ),
+        MetalMantra(
+            quote: "No clean vocals. No clean drafts. Just raw, unfiltered truth.",
+            attribution: "Guttural Grammar"
+        ),
+    ]
+
+    public static func random() -> MetalMantra {
+        all.randomElement() ?? all[0]
+    }
+}
+
+#endif

--- a/Tests/WritersAppTests/MetalDashboardTests.swift
+++ b/Tests/WritersAppTests/MetalDashboardTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import WritersApp
+
+final class MetalDashboardTests: XCTestCase {
+
+    // MARK: - MetalMantra Tests
+
+    func testMetalMantraRandomReturnsNonNil() {
+        let mantra = MetalMantra.random()
+        XCTAssertFalse(mantra.quote.isEmpty)
+        XCTAssertFalse(mantra.attribution.isEmpty)
+    }
+
+    func testMetalMantraAllIsNotEmpty() {
+        XCTAssertGreaterThan(MetalMantra.all.count, 0)
+    }
+
+    func testMetalMantraContainsDeathcoreQuotes() {
+        let quotes = MetalMantra.all.map { $0.quote }
+        let hasBreakdownReference = quotes.contains { $0.contains("breakdown") }
+        XCTAssertTrue(hasBreakdownReference, "Should contain deathcore-themed breakdown reference")
+    }
+
+    func testMetalMantraContainsGrooveMetalQuotes() {
+        let attributions = MetalMantra.all.map { $0.attribution }
+        let hasAshesRef = attributions.contains { $0.contains("Ashes") }
+        XCTAssertTrue(hasAshesRef, "Should contain Lamb of God-inspired attribution")
+    }
+
+    func testAllMantrasHaveContent() {
+        for mantra in MetalMantra.all {
+            XCTAssertFalse(mantra.quote.isEmpty, "Mantra quote should not be empty")
+            XCTAssertFalse(mantra.attribution.isEmpty, "Mantra attribution should not be empty")
+        }
+    }
+
+    // MARK: - MetalDashboardViewModel Tests
+
+    func testViewModelInitialState() {
+        let vm = MetalDashboardViewModel()
+        XCTAssertEqual(vm.totalDocuments, 0)
+        XCTAssertEqual(vm.totalWords, 0)
+        XCTAssertEqual(vm.totalTemplates, 0)
+        XCTAssertTrue(vm.recentDocuments.isEmpty)
+        XCTAssertTrue(vm.activeGoals.isEmpty)
+        XCTAssertNil(vm.currentFocusSession)
+        XCTAssertNil(vm.selectedDocument)
+    }
+
+    func testViewModelLoadDashboardPopulatesTemplates() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+        vm.loadDashboard()
+
+        // WritersApp loads 7 default templates
+        XCTAssertEqual(vm.totalTemplates, 7)
+    }
+
+    func testViewModelLoadDashboardEmptyDocuments() {
+        let vm = MetalDashboardViewModel()
+        vm.loadDashboard()
+
+        XCTAssertEqual(vm.totalDocuments, 0)
+        XCTAssertEqual(vm.totalWords, 0)
+        XCTAssertTrue(vm.recentDocuments.isEmpty)
+    }
+
+    func testViewModelCreateBlankDocument() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+        vm.loadDashboard()
+
+        vm.createBlankDocument(title: "Reclamation", category: .novel)
+
+        XCTAssertNotNil(vm.selectedDocument)
+        XCTAssertEqual(vm.selectedDocument?.title, "Reclamation")
+        XCTAssertEqual(vm.totalDocuments, 1)
+    }
+
+    func testViewModelCreateFromTemplate() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+        vm.loadDashboard()
+
+        let templates = vm.getAllTemplates()
+        guard let poetryTemplate = templates.first(where: { $0.category == .poetry }) else {
+            XCTFail("Should have poetry template")
+            return
+        }
+
+        vm.createFromTemplate(
+            templateId: poetryTemplate.id,
+            values: ["title": "Descent", "author": "Me"]
+        )
+
+        XCTAssertNotNil(vm.selectedDocument)
+        XCTAssertEqual(vm.totalDocuments, 1)
+    }
+
+    func testViewModelRecentDocuments() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+
+        _ = app.createBlankDocument(title: "Track 1", category: .novel)
+        _ = app.createBlankDocument(title: "Track 2", category: .shortStory)
+        _ = app.createBlankDocument(title: "Track 3", category: .poetry)
+
+        vm.loadDashboard()
+
+        XCTAssertEqual(vm.recentDocuments.count, 3)
+        XCTAssertEqual(vm.totalDocuments, 3)
+    }
+
+    func testViewModelSelectDocument() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+
+        let doc = app.createBlankDocument(title: "Whitechapel Lyrics", category: .poetry)
+        vm.selectDocument(doc)
+
+        XCTAssertNotNil(vm.selectedDocument)
+        XCTAssertEqual(vm.selectedDocument?.id, doc.id)
+    }
+
+    func testViewModelGetAllTemplates() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+        let templates = vm.getAllTemplates()
+
+        XCTAssertEqual(templates.count, 7)
+    }
+
+    func testViewModelGetTemplatesByCategory() {
+        let app = WritersApp()
+        let vm = MetalDashboardViewModel(app: app)
+
+        let poetryTemplates = vm.getTemplates(for: .poetry)
+        XCTAssertGreaterThan(poetryTemplates.count, 0)
+    }
+
+    // MARK: - Focus Session Integration Tests
+
+    func testViewModelStartFocusSession() {
+        let vm = MetalDashboardViewModel()
+        vm.startFocusSession(type: .pomodoro)
+
+        XCTAssertNotNil(vm.currentFocusSession)
+        XCTAssertEqual(vm.currentFocusSession?.type, .pomodoro)
+        XCTAssertEqual(vm.currentFocusSession?.state, .active)
+    }
+
+    func testViewModelPauseFocusSession() {
+        let vm = MetalDashboardViewModel()
+        vm.startFocusSession(type: .sprint)
+        vm.pauseFocusSession()
+
+        XCTAssertEqual(vm.currentFocusSession?.state, .paused)
+    }
+
+    func testViewModelEndFocusSession() {
+        let vm = MetalDashboardViewModel()
+        vm.startFocusSession(type: .freeWrite)
+        vm.endFocusSession(finalWordCount: 500)
+
+        XCTAssertNil(vm.currentFocusSession)
+    }
+
+    // MARK: - Goal Integration Tests
+
+    func testViewModelCreateDailyGoal() {
+        let vm = MetalDashboardViewModel()
+        vm.createDailyGoal(target: 1000)
+        vm.loadGoals()
+
+        XCTAssertEqual(vm.activeGoals.count, 1)
+        XCTAssertEqual(vm.activeGoals.first?.target, 1000)
+    }
+
+    func testViewModelRecordGoalProgress() {
+        let goalManager = WritingGoalManager()
+        let vm = MetalDashboardViewModel(goalManager: goalManager)
+
+        let goal = goalManager.createDailyWordGoal(target: 500)
+        vm.recordGoalProgress(goalId: goal.id, amount: 200)
+
+        let updatedGoal = goalManager.getGoal(id: goal.id)
+        XCTAssertEqual(updatedGoal?.current, 200)
+    }
+
+    func testViewModelGoalsSummary() {
+        let goalManager = WritingGoalManager()
+        let vm = MetalDashboardViewModel(goalManager: goalManager)
+
+        _ = goalManager.createDailyWordGoal(target: 500)
+        _ = goalManager.createWeeklyWordGoal(target: 3500)
+        vm.loadGoals()
+
+        XCTAssertEqual(vm.goalsSummary.totalGoals, 2)
+        XCTAssertEqual(vm.goalsSummary.activeGoals, 2)
+    }
+
+    // MARK: - Mantra Refresh Tests
+
+    func testViewModelRefreshMantra() {
+        let vm = MetalDashboardViewModel()
+        let firstMantra = vm.currentMantra.quote
+
+        // Refresh many times - at least one should differ (probabilistic but reliable with 14 mantras)
+        var gotDifferent = false
+        for _ in 0..<50 {
+            vm.refreshMantra()
+            if vm.currentMantra.quote != firstMantra {
+                gotDifferent = true
+                break
+            }
+        }
+
+        XCTAssertTrue(gotDifferent, "Refreshing mantra should eventually produce a different quote")
+    }
+
+    // MARK: - Formatting Helper Tests
+
+    func testFormatDuration() {
+        let vm = MetalDashboardViewModel()
+        XCTAssertEqual(vm.formatDuration(0), "0m")
+        XCTAssertEqual(vm.formatDuration(300), "5m")
+        XCTAssertEqual(vm.formatDuration(3600), "1h 0m")
+        XCTAssertEqual(vm.formatDuration(5400), "1h 30m")
+    }
+
+    func testFormatTimeRemaining() {
+        let vm = MetalDashboardViewModel()
+        XCTAssertEqual(vm.formatTimeRemaining(0), "00:00")
+        XCTAssertEqual(vm.formatTimeRemaining(90), "01:30")
+        XCTAssertEqual(vm.formatTimeRemaining(1500), "25:00")
+    }
+
+    // MARK: - Icon Helper Tests
+
+    func testIconForCategory() {
+        let vm = MetalDashboardViewModel()
+        XCTAssertEqual(vm.iconForCategory(.novel), "book.closed.fill")
+        XCTAssertEqual(vm.iconForCategory(.poetry), "quote.bubble.fill")
+        XCTAssertEqual(vm.iconForCategory(.screenplay), "film.fill")
+    }
+
+    func testIconForFocusType() {
+        let vm = MetalDashboardViewModel()
+        XCTAssertEqual(vm.iconForFocusType(.freeWrite), "flame.fill")
+        XCTAssertEqual(vm.iconForFocusType(.pomodoro), "timer")
+        XCTAssertEqual(vm.iconForFocusType(.sprint), "bolt.fill")
+        XCTAssertEqual(vm.iconForFocusType(.deepWork), "moon.fill")
+    }
+}


### PR DESCRIPTION
Build a personalized iPad Pro dashboard for writers inspired by
Whitechapel and Lamb of God. Features a brutal dark theme with
blood red accents, chrome typography, and deathcore/groove metal
motivational quotes.

Dashboard sections:
- Kill Count: total words, documents, streaks, focus time stats
- The Armory: quick-start focus sessions (Pomodoro, Sprint, Deep Work)
- War Room: recent documents with category icons
- The Gauntlet: writing goals with forged progress bars and streaks
- The Forge: quick actions for new docs, templates, and goals
- Mantra Banner: rotating metal-inspired writing motivation

New files:
- MetalTheme.swift: color scheme, gradients, typography, card modifiers
- MetalDashboardViewModel.swift: bridges WritersApp services to SwiftUI
- MetalDashboardView.swift: full iPad Pro dashboard layout
- MetalDashboardTests.swift: 25+ tests covering ViewModel and theme

https://claude.ai/code/session_01XHkHVFXzQc6SSF2hZSn4iV