### PR TITLE
Add SessionStart hook to install Swift and dependencies for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install system dependencies (libsqlite3-dev needed for CSQLite module)
+if ! dpkg -s libsqlite3-dev &>/dev/null || ! dpkg -s pkg-config &>/dev/null; then
+  apt-get update -qq
+  apt-get install -y -qq libsqlite3-dev pkg-config
+fi
+
+# Install Swift via swiftly if not already installed
+if ! command -v swift &>/dev/null; then
+  apt-get update -qq
+  apt-get install -y -qq curl gnupg
+
+  curl -L https://swiftlang.github.io/swiftly/swiftly-install.sh | bash -s -- -y
+  . "${HOME}/.local/share/swiftly/env.sh"
+  swiftly install latest
+
+  # Persist PATH for the session
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "source ${HOME}/.local/share/swiftly/env.sh" >> "$CLAUDE_ENV_FILE"
+  fi
+fi
+
+# Build the project to resolve dependencies and cache build artifacts
+cd "$CLAUDE_PROJECT_DIR"
+swift build 2>&1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Sets up a session start hook that installs libsqlite3-dev, pkg-config,
and the Swift toolchain (via swiftly) when running in Claude Code on the
web. The hook also runs swift build to cache build artifacts.

https://claude.ai/code/session_01RLV13E67DVmaEvRttYBbPi