### PR TITLE
Add tor-army and tor-prox scripts for multi-instance Tor setup

### DIFF
--- a/tor-army
+++ b/tor-army
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eux
+
+n=${1:-10}
+config_dir=~/etc/tor
+
+rm -rf "$config_dir"
+mkdir -p "$config_dir"
+cd "${config_dir}"
+
+# Generate torrc and torsocks config for each instance
+for i in $(seq $n); do
+  cp /etc/tor/torrc torrc_$i
+  sed -i "s/^#SocksPort 9050.*/SocksPort $((9050+${i}))/;s|^#DataDirectory /var/lib/tor|DataDirectory /var/lib/tor${i}|" torrc_$i
+  cp /etc/tor/torsocks.conf torsocks_$i.conf
+  sed -i "s/TorPort 9050/TorPort $((9050+${i}))/" torsocks_${i}.conf
+  mkdir -p /var/lib/tor${i}
+  chmod 700 /var/lib/tor${i}
+done
+
+# Launch all instances
+for i in $(seq $n); do
+  nohup tor -f "${config_dir}/torrc_$i" >"${config_dir}/$i.log" 2>&1 &
+done
+
+echo "Started $n Tor instances (ports $((9050+1))-$((9050+n)))"
+echo "Config dir: $config_dir"

--- a/tor-prox
+++ b/tor-prox
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# tor-prox: Switch TORSOCKS_CONF_FILE to a specific Tor instance
+# Usage: source tor-prox <instance_number>
+#        Then run: torify bash (or torify <command>)
+#
+# Example:
+#   source tor-prox 4    # switch to instance 4 (port 9054)
+#   torify bash           # open a shell routed through instance 4
+#   torify curl ifconfig.me  # check your exit IP
+
+config_dir=~/etc/tor
+proxy=${1:-1}
+port=$((9050 + proxy))
+
+if [ ! -f "${config_dir}/torsocks_${proxy}.conf" ]; then
+  echo "Error: torsocks_${proxy}.conf not found in ${config_dir}"
+  echo "Run tor-army first to generate configs."
+  return 1 2>/dev/null || exit 1
+fi
+
+# If Tor instance isn't running, start it
+if ! netstat -an 2>/dev/null | grep -q "127.0.0.1:${port}" && \
+   ! ss -tln 2>/dev/null | grep -q ":${port} "; then
+  echo "Instance ${proxy} not running. Starting tor on port ${port}..."
+  nohup tor -f "${config_dir}/torrc_${proxy}" >"${config_dir}/${proxy}.log" 2>&1 &
+  sleep 3
+fi
+
+export TORSOCKS_CONF_FILE="${config_dir}/torsocks_${proxy}.conf"
+echo "Switched to Tor instance ${proxy} (SOCKS port ${port})"
+echo "TORSOCKS_CONF_FILE=${TORSOCKS_CONF_FILE}"
+echo ""
+echo "Now run: torify bash"


### PR DESCRIPTION
tor-army: Generates N Tor instances with individual torrc and torsocks
configs, each on its own SOCKS port (9051+), and launches them all.

tor-prox: Switches TORSOCKS_CONF_FILE to a specific instance so
`torify bash` or `torify <cmd>` routes through that instance.

https://claude.ai/code/session_01Kuvfmyo6e457dCw6cXX3Yq