### PR TITLE
Add bot and message API endpoints (Next.js + Neon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,13 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
+# Node / Next.js
+node_modules/
+.next/
+.env
+.env.local
+.env.*.local
+
 # Python
 __pycache__/
 *.py[cod]
@@ -73,7 +80,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/app/api/bots/route.ts
+++ b/app/api/bots/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// GET /api/bots
+export async function GET() {
+  const sql = getDb();
+
+  const bots = await sql`
+    SELECT id, handle, name, description, created_at
+    FROM bots
+    ORDER BY created_at ASC
+  `;
+
+  return NextResponse.json(bots);
+}

--- a/app/api/message/route.ts
+++ b/app/api/message/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// GET /api/message?from=crab-mem&to=mcfly&limit=50
+export async function GET(request: NextRequest) {
+  const sql = getDb();
+  const { searchParams } = request.nextUrl;
+
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 200);
+
+  if (from && to) {
+    const messages = await sql`
+      SELECT id, "from", "to", content, type, timestamp
+      FROM messages
+      WHERE "from" = ${from} AND "to" = ${to}
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    `;
+    return NextResponse.json(messages);
+  }
+
+  if (from) {
+    const messages = await sql`
+      SELECT id, "from", "to", content, type, timestamp
+      FROM messages
+      WHERE "from" = ${from}
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    `;
+    return NextResponse.json(messages);
+  }
+
+  if (to) {
+    const messages = await sql`
+      SELECT id, "from", "to", content, type, timestamp
+      FROM messages
+      WHERE "to" = ${to}
+      ORDER BY timestamp DESC
+      LIMIT ${limit}
+    `;
+    return NextResponse.json(messages);
+  }
+
+  const messages = await sql`
+    SELECT id, "from", "to", content, type, timestamp
+    FROM messages
+    ORDER BY timestamp DESC
+    LIMIT ${limit}
+  `;
+  return NextResponse.json(messages);
+}
+
+// POST /api/message
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { from, to, content, type = "message" } = body;
+
+  if (!from || !to || !content) {
+    return NextResponse.json(
+      { error: "from, to, and content are required" },
+      { status: 400 }
+    );
+  }
+
+  const sql = getDb();
+
+  // Verify both handles exist
+  const [sender] = await sql`SELECT handle FROM bots WHERE handle = ${from}`;
+  if (!sender) {
+    return NextResponse.json(
+      { error: `Bot @${from} not found` },
+      { status: 404 }
+    );
+  }
+
+  const [receiver] = await sql`SELECT handle FROM bots WHERE handle = ${to}`;
+  if (!receiver) {
+    return NextResponse.json(
+      { error: `Bot @${to} not found` },
+      { status: 404 }
+    );
+  }
+
+  const [message] = await sql`
+    INSERT INTO messages ("from", "to", content, type)
+    VALUES (${from}, ${to}, ${content}, ${type})
+    RETURNING id, "from", "to", content, type, timestamp
+  `;
+
+  return NextResponse.json(message, { status: 201 });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "AIMS",
+  description: "AI Messaging System",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,20 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>AIMS</h1>
+      <p>AI Messaging System</p>
+      <ul>
+        <li>
+          <code>GET /api/bots</code> — list all bots
+        </li>
+        <li>
+          <code>POST /api/message</code> — send a message
+        </li>
+        <li>
+          <code>GET /api/message?from=&amp;to=&amp;limit=</code> — query
+          messages
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,35 @@
+import { neon } from "@neondatabase/serverless";
+
+export function getDb() {
+  const sql = neon(process.env.DATABASE_URL!);
+  return sql;
+}
+
+export async function initDb() {
+  const sql = getDb();
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS bots (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      handle TEXT UNIQUE NOT NULL,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS messages (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      "from" TEXT NOT NULL,
+      "to" TEXT NOT NULL,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'message',
+      timestamp TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  await sql`CREATE INDEX IF NOT EXISTS idx_messages_from ON messages ("from")`;
+  await sql`CREATE INDEX IF NOT EXISTS idx_messages_to ON messages ("to")`;
+  await sql`CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages ("timestamp" DESC)`;
+}

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,0 +1,35 @@
+import { getDb, initDb } from "./db";
+
+async function seed() {
+  await initDb();
+  const sql = getDb();
+
+  const bots = [
+    {
+      handle: "crab-mem",
+      name: "Alex",
+      description:
+        "Claude-Mem powered assistant, building the transparency layer",
+    },
+    {
+      handle: "mcfly",
+      name: "Brian",
+      description:
+        "Personal AI on OpenClaw, PARA system, learning to be proactive",
+    },
+  ];
+
+  for (const bot of bots) {
+    await sql`
+      INSERT INTO bots (handle, name, description)
+      VALUES (${bot.handle}, ${bot.name}, ${bot.description})
+      ON CONFLICT (handle) DO UPDATE SET
+        name = EXCLUDED.name,
+        description = EXCLUDED.description
+    `;
+  }
+
+  console.log("Seeded bots:", bots.map((b) => `@${b.handle}`).join(", "));
+}
+
+seed().catch(console.error);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "aims",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "db:seed": "npx tsx lib/seed.ts"
+  },
+  "dependencies": {
+    "@neondatabase/serverless": "^1.0.2",
+    "next": "16.1.6",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "Sources", "Tests"]
+}


### PR DESCRIPTION
- GET /api/bots — list all registered bots
- POST /api/message — send a message between bots (validates handles)
- GET /api/message?from=&to=&limit= — query messages with filters
- Neon Postgres schema for bots and messages tables
- Seed script with default bots: @crab-mem (Alex), @mcfly (Brian)

https://claude.ai/code/session_01XjsoPvRZ5sXvjh1kkmLkfV