### PR TITLE
Implement tool loop for AI service with built-in writing tools

### DIFF
--- a/Sources/WritersApp/Models/AIModels.swift
+++ b/Sources/WritersApp/Models/AIModels.swift
@@ -337,6 +337,80 @@ public struct AIContext {
     }
 }
 
+// MARK: - Tool Definitions
+
+/// Definition of a tool that the AI can use during the tool loop
+public struct ToolDefinition {
+    public let name: String
+    public let description: String
+    public let inputSchema: [String: Any]
+
+    public init(name: String, description: String, inputSchema: [String: Any]) {
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+    }
+
+    /// Convert to dictionary format for the Claude API request body
+    public func toDict() -> [String: Any] {
+        return [
+            "name": name,
+            "description": description,
+            "input_schema": inputSchema
+        ]
+    }
+}
+
+/// A tool use request parsed from an AI response content block
+public struct ToolUseBlock {
+    public let id: String
+    public let name: String
+    public let input: [String: Any]
+
+    public init?(from dict: [String: Any]) {
+        guard let type = dict["type"] as? String, type == "tool_use",
+              let id = dict["id"] as? String,
+              let name = dict["name"] as? String else {
+            return nil
+        }
+        self.id = id
+        self.name = name
+        self.input = dict["input"] as? [String: Any] ?? [:]
+    }
+}
+
+/// Result of executing a tool, sent back to the API
+public struct ToolResult {
+    public let toolUseId: String
+    public let content: String
+    public let isError: Bool
+
+    public init(toolUseId: String, content: String, isError: Bool = false) {
+        self.toolUseId = toolUseId
+        self.content = content
+        self.isError = isError
+    }
+
+    /// Convert to dictionary format for the Claude API request body
+    public func toDict() -> [String: Any] {
+        var dict: [String: Any] = [
+            "type": "tool_result",
+            "tool_use_id": toolUseId,
+            "content": content
+        ]
+        if isError {
+            dict["is_error"] = true
+        }
+        return dict
+    }
+}
+
+/// Protocol for executing tools in the tool loop
+public protocol AIToolExecutor {
+    /// Execute a tool by name with the given input parameters
+    func executeTool(name: String, input: [String: Any]) async throws -> String
+}
+
 // MARK: - AI Response
 
 /// Response from AI assistance

--- a/Sources/WritersApp/Services/AIService.swift
+++ b/Sources/WritersApp/Services/AIService.swift
@@ -285,6 +285,164 @@ public class AIService {
         return text
     }
 
+    // MARK: - Tool Loop
+
+    /// Get AI assistance with tool support, implementing the client SDK tool loop pattern.
+    ///
+    /// This method sends the request to the Claude API with tool definitions. If Claude
+    /// responds with `stop_reason: "tool_use"`, the tools are executed via the provided
+    /// `toolExecutor`, and results are sent back. This loop continues until Claude
+    /// produces a final text response (`stop_reason: "end_turn"`).
+    public func getAssistanceWithTools(
+        text: String,
+        type: AIAssistanceType,
+        tools: [ToolDefinition],
+        toolExecutor: AIToolExecutor,
+        context: AIContext? = nil,
+        maxIterations: Int = 10
+    ) async throws -> AIResponse {
+        let prompt = type.prompt(for: text, context: context)
+        let generatedContent = try await sendRequestWithToolLoop(
+            prompt: prompt,
+            tools: tools,
+            toolExecutor: toolExecutor,
+            maxIterations: maxIterations
+        )
+
+        return AIResponse(
+            requestType: type,
+            originalText: text,
+            generatedContent: generatedContent,
+            model: configuration.model
+        )
+    }
+
+    /// Core tool loop implementation.
+    ///
+    /// Mirrors the client SDK pattern:
+    /// ```
+    /// response = client.messages.create(...)
+    /// while response.stop_reason == "tool_use":
+    ///     result = your_tool_executor(response.tool_use)
+    ///     response = client.messages.create(tool_result=result, **params)
+    /// ```
+    private func sendRequestWithToolLoop(
+        prompt: String,
+        tools: [ToolDefinition],
+        toolExecutor: AIToolExecutor,
+        maxIterations: Int
+    ) async throws -> String {
+        guard let url = URL(string: apiURL) else {
+            throw AIServiceError.invalidURL
+        }
+
+        var messages: [[String: Any]] = [
+            ["role": "user", "content": prompt]
+        ]
+
+        let toolDefs = tools.map { $0.toDict() }
+
+        for _ in 0..<maxIterations {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue(configuration.apiKey, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+            var requestBody: [String: Any] = [
+                "model": configuration.model.rawValue,
+                "max_tokens": configuration.maxTokens,
+                "temperature": configuration.temperature,
+                "messages": messages
+            ]
+
+            if !toolDefs.isEmpty {
+                requestBody["tools"] = toolDefs
+            }
+
+            request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw AIServiceError.invalidResponse
+            }
+
+            guard httpResponse.statusCode == 200 else {
+                let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+                throw AIServiceError.apiError(statusCode: httpResponse.statusCode, message: errorMessage)
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let stopReason = json["stop_reason"] as? String,
+                  let content = json["content"] as? [[String: Any]] else {
+                throw AIServiceError.invalidResponseFormat
+            }
+
+            // If the model finished with a text response, extract and return it
+            if stopReason == "end_turn" {
+                let textParts = content.compactMap { block -> String? in
+                    guard block["type"] as? String == "text" else { return nil }
+                    return block["text"] as? String
+                }
+                return textParts.joined()
+            }
+
+            // If the model wants to use tools, execute them and continue the loop
+            if stopReason == "tool_use" {
+                // Add the assistant's response (with tool_use blocks) to the conversation
+                messages.append([
+                    "role": "assistant",
+                    "content": content
+                ])
+
+                // Extract and execute each tool use block
+                let toolUseBlocks = content.compactMap { ToolUseBlock(from: $0) }
+
+                var toolResults: [[String: Any]] = []
+                for toolUse in toolUseBlocks {
+                    do {
+                        let result = try await toolExecutor.executeTool(
+                            name: toolUse.name,
+                            input: toolUse.input
+                        )
+                        toolResults.append(ToolResult(
+                            toolUseId: toolUse.id,
+                            content: result
+                        ).toDict())
+                    } catch {
+                        toolResults.append(ToolResult(
+                            toolUseId: toolUse.id,
+                            content: "Error: \(error.localizedDescription)",
+                            isError: true
+                        ).toDict())
+                    }
+                }
+
+                // Send tool results back as a user message
+                messages.append([
+                    "role": "user",
+                    "content": toolResults
+                ])
+
+                continue
+            }
+
+            // Unknown stop reason — try to extract text if available
+            let textParts = content.compactMap { block -> String? in
+                guard block["type"] as? String == "text" else { return nil }
+                return block["text"] as? String
+            }
+            if !textParts.isEmpty {
+                return textParts.joined()
+            }
+
+            throw AIServiceError.invalidResponseFormat
+        }
+
+        throw AIServiceError.toolLoopExhausted(iterations: maxIterations)
+    }
+
     // MARK: - Batch Operations
 
     /// Process multiple requests in batch
@@ -396,6 +554,8 @@ public enum AIServiceError: LocalizedError {
     case invalidResponseFormat
     case apiError(statusCode: Int, message: String)
     case networkError(Error)
+    case toolLoopExhausted(iterations: Int)
+    case toolExecutionFailed(toolName: String, reason: String)
 
     public var errorDescription: String? {
         switch self {
@@ -409,6 +569,10 @@ public enum AIServiceError: LocalizedError {
             return "API error (status \(statusCode)): \(message)"
         case .networkError(let error):
             return "Network error: \(error.localizedDescription)"
+        case .toolLoopExhausted(let iterations):
+            return "Tool loop exceeded maximum iterations (\(iterations))"
+        case .toolExecutionFailed(let toolName, let reason):
+            return "Tool '\(toolName)' execution failed: \(reason)"
         }
     }
 }

--- a/Sources/WritersApp/Services/WritingToolExecutor.swift
+++ b/Sources/WritersApp/Services/WritingToolExecutor.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+/// Built-in tool executor for writing-related tools.
+///
+/// Provides tools that Claude can use during the tool loop to interact with
+/// the app's documents, templates, and text analysis capabilities.
+public class WritingToolExecutor: AIToolExecutor {
+    private let documentManager: DocumentManager
+    private let templateManager: TemplateManager
+
+    public init(documentManager: DocumentManager, templateManager: TemplateManager) {
+        self.documentManager = documentManager
+        self.templateManager = templateManager
+    }
+
+    // MARK: - Tool Definitions
+
+    /// The set of built-in writing tools available for AI tool use
+    public static var tools: [ToolDefinition] {
+        return [
+            ToolDefinition(
+                name: "get_word_count",
+                description: "Count the number of words in a given text",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "text": [
+                            "type": "string",
+                            "description": "The text to count words in"
+                        ]
+                    ],
+                    "required": ["text"]
+                ]
+            ),
+            ToolDefinition(
+                name: "search_documents",
+                description: "Search through existing documents by query string",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "query": [
+                            "type": "string",
+                            "description": "Search query to find documents"
+                        ]
+                    ],
+                    "required": ["query"]
+                ]
+            ),
+            ToolDefinition(
+                name: "get_document",
+                description: "Retrieve a document by its title",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "title": [
+                            "type": "string",
+                            "description": "The title of the document to retrieve"
+                        ]
+                    ],
+                    "required": ["title"]
+                ]
+            ),
+            ToolDefinition(
+                name: "calculate_reading_time",
+                description: "Calculate the estimated reading time for a text",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "text": [
+                            "type": "string",
+                            "description": "The text to calculate reading time for"
+                        ]
+                    ],
+                    "required": ["text"]
+                ]
+            ),
+            ToolDefinition(
+                name: "list_templates",
+                description: "List available writing templates, optionally filtered by category",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "category": [
+                            "type": "string",
+                            "description": "Optional category to filter templates (novel, shortStory, screenplay, blogPost, article, essay, poetry, businessLetter, proposal, resume, other)"
+                        ]
+                    ],
+                    "required": [] as [String]
+                ]
+            )
+        ]
+    }
+
+    // MARK: - Tool Execution
+
+    public func executeTool(name: String, input: [String: Any]) async throws -> String {
+        switch name {
+        case "get_word_count":
+            return try executeGetWordCount(input: input)
+        case "search_documents":
+            return try executeSearchDocuments(input: input)
+        case "get_document":
+            return try executeGetDocument(input: input)
+        case "calculate_reading_time":
+            return try executeCalculateReadingTime(input: input)
+        case "list_templates":
+            return executeListTemplates(input: input)
+        default:
+            throw AIServiceError.toolExecutionFailed(
+                toolName: name,
+                reason: "Unknown tool"
+            )
+        }
+    }
+
+    // MARK: - Individual Tool Implementations
+
+    private func executeGetWordCount(input: [String: Any]) throws -> String {
+        guard let text = input["text"] as? String else {
+            throw AIServiceError.toolExecutionFailed(
+                toolName: "get_word_count",
+                reason: "Missing 'text' parameter"
+            )
+        }
+        let words = text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        return "\(words.count) words"
+    }
+
+    private func executeSearchDocuments(input: [String: Any]) throws -> String {
+        guard let query = input["query"] as? String else {
+            throw AIServiceError.toolExecutionFailed(
+                toolName: "search_documents",
+                reason: "Missing 'query' parameter"
+            )
+        }
+        let results = documentManager.searchDocuments(query: query)
+        if results.isEmpty {
+            return "No documents found matching '\(query)'"
+        }
+        return results.map { doc in
+            "- \(doc.title) (\(doc.wordCount) words, \(doc.category.rawValue))"
+        }.joined(separator: "\n")
+    }
+
+    private func executeGetDocument(input: [String: Any]) throws -> String {
+        guard let title = input["title"] as? String else {
+            throw AIServiceError.toolExecutionFailed(
+                toolName: "get_document",
+                reason: "Missing 'title' parameter"
+            )
+        }
+        let docs = documentManager.searchDocuments(query: title)
+        guard let doc = docs.first(where: {
+            $0.title.lowercased() == title.lowercased()
+        }) ?? docs.first else {
+            return "Document not found: '\(title)'"
+        }
+        return """
+        Title: \(doc.title)
+        Category: \(doc.category.rawValue)
+        Word Count: \(doc.wordCount)
+        Content:
+        \(doc.content)
+        """
+    }
+
+    private func executeCalculateReadingTime(input: [String: Any]) throws -> String {
+        guard let text = input["text"] as? String else {
+            throw AIServiceError.toolExecutionFailed(
+                toolName: "calculate_reading_time",
+                reason: "Missing 'text' parameter"
+            )
+        }
+        let wordCount = text.components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }.count
+        let minutes = max(1, wordCount / 200)
+        return "Estimated reading time: \(minutes) minute\(minutes == 1 ? "" : "s") (\(wordCount) words at ~200 words per minute)"
+    }
+
+    private func executeListTemplates(input: [String: Any]) -> String {
+        let category = input["category"] as? String
+        var templates = templateManager.getAllTemplates()
+        if let cat = category, let templateCategory = TemplateCategory(rawValue: cat) {
+            templates = templates.filter { $0.category == templateCategory }
+        }
+        if templates.isEmpty {
+            return "No templates found"
+        }
+        return templates.map { template in
+            "- \(template.name) (\(template.category.rawValue)): \(template.description)"
+        }.joined(separator: "\n")
+    }
+}

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -495,6 +495,39 @@ public class WritersApp {
         return try await ai.getWritingInsights(document: document)
     }
 
+    /// Get AI assistance with tool support (implements the tool loop pattern).
+    ///
+    /// This enables Claude to use built-in writing tools (word count, document search,
+    /// template listing, reading time) during its response generation. The tool loop
+    /// continues until Claude produces a final text response.
+    public func getAIAssistanceWithTools(
+        documentId: UUID,
+        type: AIAssistanceType,
+        context: AIContext? = nil,
+        maxIterations: Int = 10
+    ) async throws -> AIResponse {
+        guard let ai = aiService else {
+            throw AIError.aiNotEnabled
+        }
+        guard let document = documentManager.getDocument(id: documentId) else {
+            throw AIError.documentNotFound
+        }
+
+        let toolExecutor = WritingToolExecutor(
+            documentManager: documentManager,
+            templateManager: templateManager
+        )
+
+        return try await ai.getAssistanceWithTools(
+            text: document.content,
+            type: type,
+            tools: WritingToolExecutor.tools,
+            toolExecutor: toolExecutor,
+            context: context,
+            maxIterations: maxIterations
+        )
+    }
+
     /// Brainstorm ideas for a topic
     public func brainstormIdeas(
         topic: String,

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -118,4 +118,289 @@ final class WritersAppTests: XCTestCase {
         let document = template.createDocument(with: ["name": "John", "age": "30"])
         XCTAssertEqual(document.content, "Hello John, you are 30 years old.")
     }
+
+    // MARK: - Tool Loop Types Tests
+
+    func testToolDefinitionToDict() {
+        let tool = ToolDefinition(
+            name: "test_tool",
+            description: "A test tool",
+            inputSchema: [
+                "type": "object",
+                "properties": [
+                    "input": ["type": "string"]
+                ],
+                "required": ["input"]
+            ]
+        )
+
+        let dict = tool.toDict()
+        XCTAssertEqual(dict["name"] as? String, "test_tool")
+        XCTAssertEqual(dict["description"] as? String, "A test tool")
+        XCTAssertNotNil(dict["input_schema"])
+    }
+
+    func testToolUseBlockParsing() {
+        let validDict: [String: Any] = [
+            "type": "tool_use",
+            "id": "toolu_123",
+            "name": "get_word_count",
+            "input": ["text": "hello world"]
+        ]
+
+        let block = ToolUseBlock(from: validDict)
+        XCTAssertNotNil(block)
+        XCTAssertEqual(block?.id, "toolu_123")
+        XCTAssertEqual(block?.name, "get_word_count")
+        XCTAssertEqual(block?.input["text"] as? String, "hello world")
+    }
+
+    func testToolUseBlockRejectsInvalidType() {
+        let invalidDict: [String: Any] = [
+            "type": "text",
+            "text": "Hello"
+        ]
+
+        let block = ToolUseBlock(from: invalidDict)
+        XCTAssertNil(block, "Should return nil for non-tool_use blocks")
+    }
+
+    func testToolUseBlockRejectsMissingFields() {
+        let missingId: [String: Any] = [
+            "type": "tool_use",
+            "name": "get_word_count"
+        ]
+
+        XCTAssertNil(ToolUseBlock(from: missingId), "Should return nil when id is missing")
+
+        let missingName: [String: Any] = [
+            "type": "tool_use",
+            "id": "toolu_123"
+        ]
+
+        XCTAssertNil(ToolUseBlock(from: missingName), "Should return nil when name is missing")
+    }
+
+    func testToolUseBlockDefaultsToEmptyInput() {
+        let noInput: [String: Any] = [
+            "type": "tool_use",
+            "id": "toolu_456",
+            "name": "list_templates"
+        ]
+
+        let block = ToolUseBlock(from: noInput)
+        XCTAssertNotNil(block)
+        XCTAssertTrue(block?.input.isEmpty ?? false)
+    }
+
+    func testToolResultToDict() {
+        let result = ToolResult(
+            toolUseId: "toolu_123",
+            content: "42 words"
+        )
+
+        let dict = result.toDict()
+        XCTAssertEqual(dict["type"] as? String, "tool_result")
+        XCTAssertEqual(dict["tool_use_id"] as? String, "toolu_123")
+        XCTAssertEqual(dict["content"] as? String, "42 words")
+        XCTAssertNil(dict["is_error"], "Should not include is_error when false")
+    }
+
+    func testToolResultErrorToDict() {
+        let result = ToolResult(
+            toolUseId: "toolu_789",
+            content: "Error: Missing parameter",
+            isError: true
+        )
+
+        let dict = result.toDict()
+        XCTAssertEqual(dict["type"] as? String, "tool_result")
+        XCTAssertEqual(dict["is_error"] as? Bool, true)
+        XCTAssertEqual(dict["content"] as? String, "Error: Missing parameter")
+    }
+
+    // MARK: - WritingToolExecutor Tests
+
+    func testWritingToolExecutorWordCount() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "get_word_count",
+            input: ["text": "The quick brown fox jumps over the lazy dog"]
+        )
+        XCTAssertEqual(result, "9 words")
+    }
+
+    func testWritingToolExecutorWordCountEmpty() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "get_word_count",
+            input: ["text": ""]
+        )
+        XCTAssertEqual(result, "0 words")
+    }
+
+    func testWritingToolExecutorSearchDocuments() async throws {
+        let doc = Document(title: "My Novel Draft", content: "Once upon a time", category: .novel)
+        app.documentManager.createDocument(doc)
+
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "search_documents",
+            input: ["query": "Novel"]
+        )
+        XCTAssertTrue(result.contains("My Novel Draft"))
+    }
+
+    func testWritingToolExecutorSearchDocumentsNoResults() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "search_documents",
+            input: ["query": "nonexistent xyz"]
+        )
+        XCTAssertTrue(result.contains("No documents found"))
+    }
+
+    func testWritingToolExecutorGetDocument() async throws {
+        let doc = Document(title: "Test Story", content: "Story content here", category: .shortStory)
+        app.documentManager.createDocument(doc)
+
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "get_document",
+            input: ["title": "Test Story"]
+        )
+        XCTAssertTrue(result.contains("Test Story"))
+        XCTAssertTrue(result.contains("Story content here"))
+        XCTAssertTrue(result.contains("shortStory"))
+    }
+
+    func testWritingToolExecutorGetDocumentNotFound() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "get_document",
+            input: ["title": "Nonexistent"]
+        )
+        XCTAssertTrue(result.contains("Document not found"))
+    }
+
+    func testWritingToolExecutorCalculateReadingTime() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        // 400 words = ~2 minutes at 200 wpm
+        let words = Array(repeating: "word", count: 400).joined(separator: " ")
+        let result = try await executor.executeTool(
+            name: "calculate_reading_time",
+            input: ["text": words]
+        )
+        XCTAssertTrue(result.contains("2 minutes"))
+        XCTAssertTrue(result.contains("400 words"))
+    }
+
+    func testWritingToolExecutorListTemplates() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "list_templates",
+            input: [:]
+        )
+        // Should list all default templates
+        XCTAssertFalse(result.contains("No templates found"))
+        XCTAssertTrue(result.contains("-"))
+    }
+
+    func testWritingToolExecutorListTemplatesFiltered() async throws {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        let result = try await executor.executeTool(
+            name: "list_templates",
+            input: ["category": "novel"]
+        )
+        // Should only list novel templates
+        XCTAssertTrue(result.contains("novel"))
+    }
+
+    func testWritingToolExecutorUnknownTool() async {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        do {
+            _ = try await executor.executeTool(name: "unknown_tool", input: [:])
+            XCTFail("Should throw for unknown tool")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("Unknown tool"))
+        }
+    }
+
+    func testWritingToolExecutorMissingParameter() async {
+        let executor = WritingToolExecutor(
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+
+        do {
+            _ = try await executor.executeTool(name: "get_word_count", input: [:])
+            XCTFail("Should throw for missing parameter")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("Missing"))
+        }
+    }
+
+    func testWritingToolsStaticDefinitions() {
+        let tools = WritingToolExecutor.tools
+        XCTAssertEqual(tools.count, 5)
+
+        let toolNames = tools.map { $0.name }
+        XCTAssertTrue(toolNames.contains("get_word_count"))
+        XCTAssertTrue(toolNames.contains("search_documents"))
+        XCTAssertTrue(toolNames.contains("get_document"))
+        XCTAssertTrue(toolNames.contains("calculate_reading_time"))
+        XCTAssertTrue(toolNames.contains("list_templates"))
+    }
+
+    func testToolLoopErrorDescriptions() {
+        let exhausted = AIServiceError.toolLoopExhausted(iterations: 10)
+        XCTAssertTrue(exhausted.localizedDescription.contains("10"))
+
+        let execFailed = AIServiceError.toolExecutionFailed(
+            toolName: "test_tool",
+            reason: "something broke"
+        )
+        XCTAssertTrue(execFailed.localizedDescription.contains("test_tool"))
+        XCTAssertTrue(execFailed.localizedDescription.contains("something broke"))
+    }
 }


### PR DESCRIPTION
Add the client SDK tool loop pattern to AIService, enabling Claude to
autonomously call tools during response generation. When the API responds
with stop_reason "tool_use", registered tools are executed and results
sent back until a final text response is produced.

- Add ToolDefinition, ToolUseBlock, ToolResult types and AIToolExecutor
  protocol in AIModels.swift
- Add sendRequestWithToolLoop() and getAssistanceWithTools() to AIService
- Create WritingToolExecutor with 5 built-in tools: get_word_count,
  search_documents, get_document, calculate_reading_time, list_templates
- Expose getAIAssistanceWithTools() on WritersApp for document-level use
- Add 20 unit tests covering type serialization, tool execution, error
  handling, and edge cases

https://claude.ai/code/session_015CRAss21p3NgMWvuUQxYEK