### PR TITLE
Add file-based knowledge system with knowledge-advisor subagent

### DIFF
--- a/.claude/agents/knowledge-advisor.md
+++ b/.claude/agents/knowledge-advisor.md
@@ -1,0 +1,67 @@
+---
+name: knowledge-advisor
+description: Consult this agent before making any code change to retrieve the applicable project standards. Given a description of what you are about to build or modify, it reads the relevant knowledge base files and returns all rules that apply. Use proactively before writing or editing Swift source files, adding templates, or implementing AI features.
+tools: Read, Glob
+model: haiku
+---
+
+You are the knowledge advisor for the friendly-outlaw Swift writers app. Your job is to read the project knowledge base and return every standard that applies to the task described by the caller.
+
+## Knowledge Base Location
+
+All standards live in `.claude/knowledge/`:
+- `index.json` — category index and file map
+- `swift.json` — Swift coding standards
+- `architecture.json` — architecture patterns and how-to steps
+- `security.json` — security rules
+- `templates.json` — writing template standards
+- `testing.json` — testing standards
+
+## Workflow
+
+1. Read `.claude/knowledge/index.json` to understand available categories.
+2. Based on the task description, decide which categories are relevant:
+   - Any Swift source change → **swift** + **architecture** + **testing**
+   - New AI feature → **swift** + **architecture** + **security** + **testing**
+   - New template → **templates** + **testing**
+   - Security-sensitive change (API keys, network, user input) → **security**
+   - All changes → always include **testing**
+3. Read each relevant category file.
+4. Return a structured report of all applicable rules.
+
+## Output Format
+
+For each relevant category, list the rules that apply. Use this format:
+
+```
+## [Category Name] Standards
+
+**[rule-id]** [title] (severity: required/warning/critical/guidance)
+[rule text or steps]
+
+...
+```
+
+After listing all rules, add a short **Checklist** section — a bullet list of concrete things to verify before committing:
+
+```
+## Pre-commit Checklist
+
+- [ ] [specific check derived from the rules above]
+- [ ] [another check]
+...
+```
+
+Be concise. Do not pad the output. If a rule is clearly irrelevant to the specific task, omit it.
+
+## Example
+
+Caller: "I am adding a new async method to AIService that generates chapter outlines."
+
+You would read: swift.json, architecture.json, security.json, testing.json
+
+Then return rules from:
+- swift: swift-004 (async throws), swift-003 (optionals), swift-002 (MARK sections)
+- architecture: arch-002 (service pattern), arch-004 (adding AI feature steps)
+- security: sec-001 (no hardcoded keys), sec-003 (input sanitisation), sec-005 (network only from AIService), sec-006 (API version header)
+- testing: test-001 (all tests pass), test-004 (AI method testing guidance)

--- a/.claude/knowledge/architecture.json
+++ b/.claude/knowledge/architecture.json
@@ -1,0 +1,81 @@
+{
+  "category": "architecture",
+  "description": "Architecture patterns and structural rules for the friendly-outlaw project",
+  "rules": [
+    {
+      "id": "arch-001",
+      "title": "Manager pattern",
+      "severity": "required",
+      "rule": "Template lifecycle goes through TemplateManager. Document CRUD, search, and statistics go through DocumentManager. Do not bypass these managers with direct data manipulation."
+    },
+    {
+      "id": "arch-002",
+      "title": "Service pattern",
+      "severity": "required",
+      "rule": "All Anthropic API communication is encapsulated in AIService. The WritersApp class exposes a subset of AIService methods as the public API. Do not call the Anthropic API from outside AIService."
+    },
+    {
+      "id": "arch-003",
+      "title": "AI feature gating",
+      "severity": "required",
+      "rule": "AI features are optional. The app must degrade gracefully when no API key is present. Always check that AI is enabled (via enableAI()) before calling AI operations. The CLI auto-detects ANTHROPIC_API_KEY."
+    },
+    {
+      "id": "arch-004",
+      "title": "Adding a new AI feature",
+      "severity": "guidance",
+      "steps": [
+        "Add method to Sources/WritersApp/Services/AIService.swift",
+        "Create a system prompt and user prompt inside that method",
+        "Add the assistance type to AIAssistanceType enum in AIModels.swift",
+        "Expose the method via WritersApp.swift if it should be part of the public API",
+        "Add a CLI option in Sources/WritersAppCLI/main.swift if applicable"
+      ]
+    },
+    {
+      "id": "arch-005",
+      "title": "Adding a new template",
+      "severity": "guidance",
+      "steps": [
+        "Edit Sources/WritersApp/Services/TemplateManager.swift",
+        "Add to the loadDefaultTemplates() method",
+        "Define placeholders using the Placeholder struct",
+        "Verify every {{key}} in content has a matching Placeholder entry and vice versa",
+        "Update tests if the template count assertion exists"
+      ]
+    },
+    {
+      "id": "arch-006",
+      "title": "Adding a new export format",
+      "severity": "guidance",
+      "steps": [
+        "Add a case to the export format enum",
+        "Implement the conversion inside exportDocument()",
+        "Add a test case for the new format"
+      ]
+    },
+    {
+      "id": "arch-007",
+      "title": "Modifying models",
+      "severity": "guidance",
+      "steps": [
+        "Update the struct in Sources/WritersApp/Models/",
+        "Ensure Codable conformance is maintained",
+        "Update the related manager methods",
+        "Update tests to cover the change"
+      ]
+    },
+    {
+      "id": "arch-008",
+      "title": "Entry points",
+      "severity": "required",
+      "rule": "WritersApp.swift is the main library entry point and public API surface. main.swift is the CLI entry point. Changes to the public API in WritersApp.swift may break external consumers — prefer additive changes."
+    },
+    {
+      "id": "arch-009",
+      "title": "Date serialisation",
+      "severity": "required",
+      "rule": "All dates must use ISO 8601 format for JSON serialisation."
+    }
+  ]
+}

--- a/.claude/knowledge/index.json
+++ b/.claude/knowledge/index.json
@@ -1,0 +1,31 @@
+{
+  "description": "Knowledge base index for the friendly-outlaw project. Each file contains structured standards that agents should consult before making changes.",
+  "categories": [
+    {
+      "id": "swift",
+      "file": "swift.json",
+      "description": "Swift language coding standards — naming, optionals, async/await, Codable, dependencies"
+    },
+    {
+      "id": "architecture",
+      "file": "architecture.json",
+      "description": "Architecture patterns — manager/service layers, AI feature gating, how to add features"
+    },
+    {
+      "id": "security",
+      "file": "security.json",
+      "description": "Security rules — no hardcoded secrets, input sanitisation, network call policy"
+    },
+    {
+      "id": "templates",
+      "file": "templates.json",
+      "description": "Writing template standards — placeholder format, count, descriptions, category assignment"
+    },
+    {
+      "id": "testing",
+      "file": "testing.json",
+      "description": "Testing standards — what to test, naming, AI method testing approach"
+    }
+  ],
+  "usage": "Before making a code change, read the relevant category files. For Swift changes: swift.json + architecture.json. For new templates: templates.json. For AI features: architecture.json + security.json. For any change: testing.json."
+}

--- a/.claude/knowledge/security.json
+++ b/.claude/knowledge/security.json
@@ -1,0 +1,48 @@
+{
+  "category": "security",
+  "description": "Security rules for the friendly-outlaw project",
+  "rules": [
+    {
+      "id": "sec-001",
+      "title": "No hardcoded secrets",
+      "severity": "critical",
+      "rule": "Never hardcode API keys, tokens, or secrets in source files. The Anthropic API key must come from the ANTHROPIC_API_KEY environment variable or be passed by the caller at runtime. Any file containing a real key must not be committed."
+    },
+    {
+      "id": "sec-002",
+      "title": "API key handling",
+      "severity": "critical",
+      "rule": "API keys must not appear in log output, error messages, or string interpolation. When constructing AIConfiguration, accept the key as a parameter — never read process environment directly inside a library method."
+    },
+    {
+      "id": "sec-003",
+      "title": "User input sanitisation",
+      "severity": "required",
+      "rule": "Do not pass raw user input directly as prompt content without validation. Validate that placeholder values are non-empty strings where required. Limit input lengths before sending to the API."
+    },
+    {
+      "id": "sec-004",
+      "title": "No shell injection",
+      "severity": "critical",
+      "rule": "Never construct shell commands by concatenating user-supplied strings. Any use of Process() or shell invocation must use fixed argument arrays, not interpolated strings."
+    },
+    {
+      "id": "sec-005",
+      "title": "Network calls only from AIService",
+      "severity": "required",
+      "rule": "All outbound network requests must go through AIService. Do not add URLSession calls elsewhere. This ensures a single audit point for network activity."
+    },
+    {
+      "id": "sec-006",
+      "title": "Anthropic API version header",
+      "severity": "required",
+      "rule": "Every request to the Anthropic API must include the 'anthropic-version: 2023-06-01' header. Do not omit it or use a different value without testing."
+    },
+    {
+      "id": "sec-007",
+      "title": "Error messages",
+      "severity": "warning",
+      "rule": "Error messages shown to the user must not expose internal implementation details, file paths, or stack traces. Use typed errors (AIError, AIServiceError) with user-facing messages."
+    }
+  ]
+}

--- a/.claude/knowledge/swift.json
+++ b/.claude/knowledge/swift.json
@@ -1,0 +1,66 @@
+{
+  "category": "swift",
+  "description": "Swift coding standards for the friendly-outlaw project",
+  "rules": [
+    {
+      "id": "swift-001",
+      "title": "Naming conventions",
+      "severity": "required",
+      "rule": "Methods use verb names (createDocument, improveText). Properties use descriptive nouns (wordCount, readingTime). Types use UpperCamelCase. Variables/properties use lowerCamelCase."
+    },
+    {
+      "id": "swift-002",
+      "title": "Code organisation",
+      "severity": "required",
+      "rule": "Use '// MARK: - Section Name' to divide files into sections. Public interface at the top, private implementation below."
+    },
+    {
+      "id": "swift-003",
+      "title": "Optionals",
+      "severity": "required",
+      "rule": "Never force-unwrap (!) optionals from dictionary lookups, first(where:), or external input. Use 'if let' or 'guard let'. Force-unwrap is only acceptable for values that are truly programmer errors if nil (e.g., Bundle resources)."
+    },
+    {
+      "id": "swift-004",
+      "title": "Async/await",
+      "severity": "required",
+      "rule": "All AI service methods must be 'async throws'. Always propagate errors with typed error types (AIError, AIServiceError). Never swallow errors silently."
+    },
+    {
+      "id": "swift-005",
+      "title": "Codable conformance",
+      "severity": "required",
+      "rule": "All model structs (Document, Template, AIConfiguration) must maintain Codable conformance. When adding stored properties, update CodingKeys if a custom implementation exists."
+    },
+    {
+      "id": "swift-006",
+      "title": "Data types",
+      "severity": "required",
+      "rule": "Use structs for data (Document, Template, AIConfiguration). Use classes for services (WritersApp, TemplateManager, DocumentManager, AIService). Use enums for domain types (TemplateCategory, AIModel, WritingTone, AIAssistanceType)."
+    },
+    {
+      "id": "swift-007",
+      "title": "Identifiable conformance",
+      "severity": "required",
+      "rule": "All entities must have a UUID 'id' property and conform to Identifiable."
+    },
+    {
+      "id": "swift-008",
+      "title": "Linux compatibility",
+      "severity": "required",
+      "rule": "Use '#if canImport(FoundationNetworking)' guard when importing FoundationNetworking for URLSession on Linux. The project runs on both macOS and Linux CI."
+    },
+    {
+      "id": "swift-009",
+      "title": "Closures and retain cycles",
+      "severity": "warning",
+      "rule": "Use [weak self] in closures that capture self when self outlives the closure's scope. Avoid unnecessary 'self.' references inside closures where capture is not needed."
+    },
+    {
+      "id": "swift-010",
+      "title": "No external dependencies",
+      "severity": "required",
+      "rule": "The project has zero external dependencies — only the Swift standard library and Foundation. Do not add packages to Package.swift without explicit discussion."
+    }
+  ]
+}

--- a/.claude/knowledge/templates.json
+++ b/.claude/knowledge/templates.json
@@ -1,0 +1,42 @@
+{
+  "category": "templates",
+  "description": "Standards for writing templates in the friendly-outlaw app",
+  "rules": [
+    {
+      "id": "tmpl-001",
+      "title": "Placeholder format",
+      "severity": "required",
+      "rule": "Placeholder keys must use {{snake_case}} format — lowercase letters and underscores only. Every {{key}} referenced in content must have a matching Placeholder struct entry, and every Placeholder entry must be referenced in content."
+    },
+    {
+      "id": "tmpl-002",
+      "title": "Placeholder count",
+      "severity": "guidance",
+      "rule": "Good templates have 3–8 placeholders. Fewer than 3 is too rigid; more than 8 is overwhelming for writers."
+    },
+    {
+      "id": "tmpl-003",
+      "title": "Placeholder descriptions",
+      "severity": "required",
+      "rule": "Each Placeholder must have a clear, writer-friendly 'description' field explaining what to write there. Use a realistic 'defaultValue' where it helps (e.g., 'My Story Title'), or an empty string for open-ended fields."
+    },
+    {
+      "id": "tmpl-004",
+      "title": "Category assignment",
+      "severity": "required",
+      "rule": "Assign the most specific TemplateCategory that fits: novel, shortStory, screenplay, blogPost, article, essay, poetry, businessLetter, proposal, resume, other. Do not use 'other' if a more specific category applies."
+    },
+    {
+      "id": "tmpl-005",
+      "title": "Template structure",
+      "severity": "guidance",
+      "rule": "Templates should include genre-appropriate headings and structure. A novel chapter template should have scene-setting sections; a blog post template should have an intro, body sections, and a conclusion."
+    },
+    {
+      "id": "tmpl-006",
+      "title": "New template categories",
+      "severity": "required",
+      "rule": "If a new TemplateCategory value is needed, add it to the TemplateCategory enum in Sources/WritersApp/Models/Template.swift before using it in a template definition."
+    }
+  ]
+}

--- a/.claude/knowledge/testing.json
+++ b/.claude/knowledge/testing.json
@@ -1,0 +1,36 @@
+{
+  "category": "testing",
+  "description": "Testing standards for the friendly-outlaw project",
+  "rules": [
+    {
+      "id": "test-001",
+      "title": "Test runner",
+      "severity": "required",
+      "rule": "Run 'swift test' from the project root after any source change. All 11 existing tests must pass before committing. Never commit with a failing test."
+    },
+    {
+      "id": "test-002",
+      "title": "Test coverage areas",
+      "severity": "guidance",
+      "rule": "Tests live in Tests/WritersAppTests/WritersAppTests.swift. The existing suite covers: template loading and search, document creation (from template and blank), word count calculation, DocumentManager CRUD, export formats (.markdown, .plainText, .html), statistics generation, and placeholder substitution."
+    },
+    {
+      "id": "test-003",
+      "title": "New feature tests",
+      "severity": "required",
+      "rule": "Every new public method on WritersApp, TemplateManager, or DocumentManager must have at least one test case. New template additions must not break the existing template count assertion if one exists."
+    },
+    {
+      "id": "test-004",
+      "title": "AI feature tests",
+      "severity": "guidance",
+      "rule": "AI service methods (async throws) should not be tested with live API calls in the test suite. Test the surrounding logic (prompt construction, error handling paths) with mocks or by testing the non-AI layers."
+    },
+    {
+      "id": "test-005",
+      "title": "Test naming",
+      "severity": "guidance",
+      "rule": "Test method names must start with 'test' and clearly describe what is being tested, e.g., testDocumentWordCountIsAccurate, testPlaceholderSubstitutionReplacesAllKeys."
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,36 @@ Run with: `swift test`
 |----------|---------|
 | `ANTHROPIC_API_KEY` | Claude API key for AI features |
 
+## Knowledge System
+
+Project standards live in `.claude/knowledge/` as structured JSON files. Before making any code change, consult the relevant files or use the **knowledge-advisor** subagent to retrieve applicable rules automatically.
+
+### Knowledge Base Files
+
+| File | Covers |
+|------|--------|
+| `index.json` | Category index and usage guide |
+| `swift.json` | Naming, optionals, async/await, Codable, no-external-deps |
+| `architecture.json` | Manager/service layers, how to add features, entry points |
+| `security.json` | No hardcoded secrets, input sanitisation, network policy |
+| `templates.json` | Placeholder format, count, descriptions, categories |
+| `testing.json` | What to test, naming conventions, AI method approach |
+
+### Using the Knowledge Advisor Agent
+
+The **knowledge-advisor** subagent reads the relevant files and returns a focused rule list plus a pre-commit checklist for your specific task. Invoke it before writing code:
+
+> "I am about to add a new async method to AIService for generating chapter outlines. What standards apply?"
+
+The agent selects the right categories (swift + architecture + security + testing for an AI feature), reads the JSON files, and returns only the rules that matter for that task.
+
+### Quick Reference — Which Files to Read
+
+- **Any Swift change**: `swift.json` + `architecture.json` + `testing.json`
+- **New AI feature**: all of the above + `security.json`
+- **New template**: `templates.json` + `testing.json`
+- **Security-sensitive change**: `security.json`
+
 ## Common Tasks for AI Assistants
 
 ### Adding a New Template


### PR DESCRIPTION
- Add .claude/knowledge/ with six JSON standards files covering Swift
  conventions, architecture patterns, security rules, template standards,
  and testing requirements — all grounded in the existing codebase docs
- Add .claude/agents/knowledge-advisor.md subagent that reads the relevant
  category files for a given task and returns a focused rule list plus a
  pre-commit checklist
- Update CLAUDE.md with a Knowledge System section documenting which files
  to read for each type of change and how to invoke the advisor agent

https://claude.ai/code/session_01NP2u7fbvksChhTw33CgMam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established centralized knowledge base with standards spanning architecture rules, security practices, Swift coding conventions, template guidelines, and testing requirements.
  * Introduced Knowledge Advisor agent documentation to automate selection and delivery of applicable project standards based on task context.
  * Added comprehensive quick reference guides for common development workflows and task-oriented assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->