### PR TITLE
Add CHANGELOG.md with Claude Code 2.1.50 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## 2.1.50
+
+### Fewer memory leaks
+
+This release addresses six or seven distinct memory leaks — agent task state, LSP diagnostics, completed task output, circular buffers, shell process refs — basically anything that could accumulate in long sessions was audited and fixed. Combined with new cache clearing after compaction and capped file history snapshots, this should make for more reliable long sessions.
+
+### Better session reliability
+
+This got some well-deserved attention too. In previous releases, symlinked working directories could make resumed sessions invisible, and SSH disconnects could lose data. Both of these problems were fixed.
+
+### Other wins
+
+Agents can declaratively run in isolated git worktrees, with new hook events for custom setup/teardown. `CLAUDE_CODE_SIMPLE` mode is now *actually* simple, stripping MCP tools, hooks, CLAUDE.md, skills, session memory, etc. And finally: Opus 4.6 fast mode gets full 1M context.
+
+### Full changelog
+
+- Added support for `startupTimeout` configuration for LSP servers
+- Added `WorktreeCreate` and `WorktreeRemove` hook events, enabling custom VCS setup and teardown when agent worktree isolation creates or removes worktrees.
+- Fixed a bug where resumed sessions could be invisible when the working directory involved symlinks, because the session storage path was resolved at different times during startup. Also fixed session data loss on SSH disconnect by flushing session data before hooks and analytics in the graceful shutdown sequence.
+- Linux: Fixed native modules not loading on systems with glibc older than 2.30 (e.g., RHEL 8)
+- Fixed memory leak in agent teams where completed teammate tasks were never garbage collected from session state
+- Fixed `CLAUDE_CODE_SIMPLE` to fully strip down skills, session memory, custom agents, and CLAUDE.md token counting
+- Fixed `/mcp reconnect` freezing the CLI when given a server name that doesn't exist
+- Fixed memory leak where completed task state objects were never removed from AppState
+- Added support for `isolation: worktree` in agent definitions, allowing agents to declaratively run in isolated git worktrees.
+- `CLAUDE_CODE_SIMPLE` mode now also disables MCP tools, attachments, hooks, and CLAUDE.md file loading for a fully minimal experience.
+- Fixed bug where MCP tools were not discovered when tool search is enabled and a prompt is passed in as a launch argument
+- Improved memory usage during long sessions by clearing internal caches after compaction
+- Added `claude agents` CLI command to list all configured agents
+- Improved memory usage during long sessions by clearing large tool results after they have been processed
+- Fixed a memory leak where LSP diagnostic data was never cleaned up after delivery, causing unbounded memory growth in long sessions
+- Fixed a memory leak where completed task output was not freed from memory, reducing memory usage in long sessions with many tasks
+- Improved startup performance for headless mode (`-p` flag) by deferring Yoga WASM and UI component imports
+- Fixed prompt suggestion cache regression that reduced cache hit rates
+- Fixed unbounded memory growth in long sessions by capping file history snapshots
+- Added `CLAUDE_CODE_DISABLE_1M_CONTEXT` environment variable to disable 1M context window support
+- Opus 4.6 (fast mode) now includes the full 1M context window
+- VSCode: Added `/extra-usage` command support in VS Code sessions
+- Fixed memory leak where TaskOutput retained recent lines after cleanup
+- Fixed memory leak in CircularBuffer where cleared items were retained in the backing array
+- Fixed memory leak in shell command execution where ChildProcess and AbortController references were retained after cleanup


### PR DESCRIPTION
Documents memory leak fixes, session reliability improvements, and
new features including worktree isolation, CLAUDE_CODE_SIMPLE updates,
and 1M context for Opus 4.6 fast mode.

https://claude.ai/code/session_018Y8gTgjk8NYApXyVKv5A1M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opus 4.6 fast mode now supports full 1M token context
  * Agent isolation in git worktrees
  * New hook events for setup/teardown operations
  * Claude agents CLI command

* **Bug Fixes**
  * Fixed memory leaks across multiple components
  * Improved session reliability with symlink and SSH disconnect handling
  * Fixed MCP tool discovery and prompt launch issues
  * Enhanced Linux glibc compatibility

* **Performance Improvements**
  * Optimized memory usage through cache clearing strategies
  * Faster startup performance for headless mode
  * Improved prompt suggestion cache stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->