### PR TITLE
Add Kanban task manager feature with Backlog→Planning→Running→Review→Done workflow

### DIFF
--- a/Sources/WritersApp/Models/KanbanModels.swift
+++ b/Sources/WritersApp/Models/KanbanModels.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// MARK: - KanbanColumn
+
+/// The column (stage) a Kanban task occupies in the workflow
+public enum KanbanColumn: String, Codable, CaseIterable {
+    case backlog = "backlog"
+    case planning = "planning"
+    case running = "running"
+    case review = "review"
+    case done = "done"
+
+    public var displayName: String {
+        switch self {
+        case .backlog: return "Backlog"
+        case .planning: return "Planning"
+        case .running: return "Running"
+        case .review: return "Review"
+        case .done: return "Done"
+        }
+    }
+
+    /// Returns the next column in the workflow, or nil if already at done
+    public var next: KanbanColumn? {
+        switch self {
+        case .backlog: return .planning
+        case .planning: return .running
+        case .running: return .review
+        case .review: return .done
+        case .done: return nil
+        }
+    }
+
+    /// Returns the previous column in the workflow, or nil if already at backlog
+    public var previous: KanbanColumn? {
+        switch self {
+        case .backlog: return nil
+        case .planning: return .backlog
+        case .running: return .planning
+        case .review: return .running
+        case .done: return .review
+        }
+    }
+}
+
+// MARK: - KanbanTask
+
+/// A task managed on the Kanban board
+public struct KanbanTask: Codable, Identifiable {
+    public let id: UUID
+    public var title: String
+    public var description: String
+    public var column: KanbanColumn
+    public let boardId: UUID
+    public var metadata: KanbanTaskMetadata
+
+    public init(
+        id: UUID = UUID(),
+        title: String,
+        description: String = "",
+        column: KanbanColumn = .backlog,
+        boardId: UUID,
+        metadata: KanbanTaskMetadata = KanbanTaskMetadata()
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.column = column
+        self.boardId = boardId
+        self.metadata = metadata
+    }
+}
+
+// MARK: - KanbanTaskMetadata
+
+/// Metadata associated with a Kanban task
+public struct KanbanTaskMetadata: Codable {
+    public var created: Date
+    public var modified: Date
+    public var completedAt: Date?
+    public var tags: [String]
+    public var notes: String
+
+    public init(
+        created: Date = Date(),
+        modified: Date = Date(),
+        completedAt: Date? = nil,
+        tags: [String] = [],
+        notes: String = ""
+    ) {
+        self.created = created
+        self.modified = modified
+        self.completedAt = completedAt
+        self.tags = tags
+        self.notes = notes
+    }
+}
+
+// MARK: - KanbanBoard
+
+/// A Kanban board grouping tasks into columns
+public struct KanbanBoard: Codable, Identifiable {
+    public let id: UUID
+    public var name: String
+    public var description: String
+    public var metadata: KanbanBoardMetadata
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        description: String = "",
+        metadata: KanbanBoardMetadata = KanbanBoardMetadata()
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.metadata = metadata
+    }
+}
+
+// MARK: - KanbanBoardMetadata
+
+/// Metadata associated with a Kanban board
+public struct KanbanBoardMetadata: Codable {
+    public var created: Date
+    public var modified: Date
+
+    public init(
+        created: Date = Date(),
+        modified: Date = Date()
+    ) {
+        self.created = created
+        self.modified = modified
+    }
+}

--- a/Sources/WritersApp/Services/KanbanManager.swift
+++ b/Sources/WritersApp/Services/KanbanManager.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Manages Kanban boards and tasks through their workflow lifecycle
+public class KanbanManager {
+    private var boards: [UUID: KanbanBoard]
+    private var tasks: [UUID: KanbanTask]
+
+    public init() {
+        self.boards = [:]
+        self.tasks = [:]
+    }
+
+    // MARK: - Board Management
+
+    /// Creates a new Kanban board
+    public func createBoard(_ board: KanbanBoard) {
+        boards[board.id] = board
+    }
+
+    /// Retrieves a board by ID
+    public func getBoard(id: UUID) -> KanbanBoard? {
+        return boards[id]
+    }
+
+    /// Retrieves all boards sorted by creation date descending
+    public func getAllBoards() -> [KanbanBoard] {
+        return Array(boards.values)
+            .sorted { $0.metadata.created > $1.metadata.created }
+    }
+
+    /// Updates an existing board
+    public func updateBoard(_ board: KanbanBoard) {
+        var updated = board
+        updated.metadata.modified = Date()
+        boards[board.id] = updated
+    }
+
+    /// Deletes a board and all its tasks
+    public func deleteBoard(id: UUID) {
+        let orphanedTaskIds = tasks.values
+            .filter { $0.boardId == id }
+            .map { $0.id }
+        boards.removeValue(forKey: id)
+        for taskId in orphanedTaskIds {
+            tasks.removeValue(forKey: taskId)
+        }
+    }
+
+    // MARK: - Task Management
+
+    /// Creates a new Kanban task on the specified board
+    public func createTask(_ task: KanbanTask) {
+        tasks[task.id] = task
+    }
+
+    /// Retrieves a task by ID
+    public func getTask(id: UUID) -> KanbanTask? {
+        return tasks[id]
+    }
+
+    /// Retrieves all tasks for a given board sorted by creation date descending
+    public func getTasks(forBoard boardId: UUID) -> [KanbanTask] {
+        return tasks.values.filter { $0.boardId == boardId }
+            .sorted { $0.metadata.created > $1.metadata.created }
+    }
+
+    /// Retrieves tasks in a specific column on a board sorted by creation date descending
+    public func getTasks(forBoard boardId: UUID, inColumn column: KanbanColumn) -> [KanbanTask] {
+        return tasks.values.filter { $0.boardId == boardId && $0.column == column }
+            .sorted { $0.metadata.created > $1.metadata.created }
+    }
+
+    /// Retrieves all tasks in a specific column across all boards sorted by creation date descending
+    public func getTasks(inColumn column: KanbanColumn) -> [KanbanTask] {
+        return tasks.values.filter { $0.column == column }
+            .sorted { $0.metadata.created > $1.metadata.created }
+    }
+
+    /// Searches tasks by title or description sorted by creation date descending
+    public func searchTasks(query: String) -> [KanbanTask] {
+        if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return Array(tasks.values).sorted { $0.metadata.created > $1.metadata.created }
+        }
+        return tasks.values.filter { task in
+            task.title.localizedCaseInsensitiveContains(query) ||
+            task.description.localizedCaseInsensitiveContains(query)
+        }.sorted { $0.metadata.created > $1.metadata.created }
+    }
+
+    /// Updates an existing task, keeping completedAt consistent with column state
+    public func updateTask(_ task: KanbanTask) {
+        var updated = task
+        updated.metadata.modified = Date()
+        if updated.column == .done && updated.metadata.completedAt == nil {
+            updated.metadata.completedAt = Date()
+        } else if updated.column != .done {
+            updated.metadata.completedAt = nil
+        }
+        tasks[task.id] = updated
+    }
+
+    /// Deletes a task by ID
+    public func deleteTask(id: UUID) {
+        tasks.removeValue(forKey: id)
+    }
+
+    // MARK: - Column Transitions
+
+    /// Moves a task to a specific column
+    public func moveTask(id: UUID, toColumn column: KanbanColumn) {
+        guard var task = tasks[id] else { return }
+        task.column = column
+        task.metadata.modified = Date()
+        if column == .done {
+            task.metadata.completedAt = Date()
+        } else {
+            task.metadata.completedAt = nil
+        }
+        tasks[id] = task
+    }
+
+    /// Advances a task to the next column in the workflow
+    /// - Returns: The new column, or nil if the task was already in Done
+    @discardableResult
+    public func advanceTask(id: UUID) -> KanbanColumn? {
+        guard let task = tasks[id], let nextColumn = task.column.next else { return nil }
+        moveTask(id: id, toColumn: nextColumn)
+        return nextColumn
+    }
+
+    /// Moves a task back to the previous column in the workflow
+    /// - Returns: The new column, or nil if the task was already in Backlog
+    @discardableResult
+    public func regressTask(id: UUID) -> KanbanColumn? {
+        guard let task = tasks[id], let previousColumn = task.column.previous else { return nil }
+        moveTask(id: id, toColumn: previousColumn)
+        return previousColumn
+    }
+
+    // MARK: - Statistics
+
+    /// Returns the count of tasks per column for a given board
+    public func getTaskCountByColumn(forBoard boardId: UUID) -> [KanbanColumn: Int] {
+        var counts: [KanbanColumn: Int] = [:]
+        for column in KanbanColumn.allCases {
+            counts[column] = tasks.values.filter { $0.boardId == boardId && $0.column == column }.count
+        }
+        return counts
+    }
+
+    /// Returns the total count of tasks per column across all boards
+    public func getTaskCountByColumn() -> [KanbanColumn: Int] {
+        var counts: [KanbanColumn: Int] = [:]
+        for column in KanbanColumn.allCases {
+            counts[column] = tasks.values.filter { $0.column == column }.count
+        }
+        return counts
+    }
+}

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -5,6 +5,7 @@ public class WritersApp {
     public let templateManager: TemplateManager
     public let documentManager: DocumentManager
     public let issueManager: IssueManager
+    public let kanbanManager: KanbanManager
     public let databaseManager: DatabaseManager
     public let pluginManager: PluginManager
     public let encouragementService: EncouragementService
@@ -17,6 +18,7 @@ public class WritersApp {
         self.templateManager = TemplateManager()
         self.documentManager = DocumentManager()
         self.issueManager = IssueManager()
+        self.kanbanManager = KanbanManager()
         self.databaseManager = DatabaseManager()
         self.pluginManager = PluginManager.shared
         self.encouragementService = EncouragementService()
@@ -28,6 +30,7 @@ public class WritersApp {
         self.templateManager = TemplateManager()
         self.documentManager = DocumentManager()
         self.issueManager = IssueManager()
+        self.kanbanManager = KanbanManager()
         self.databaseManager = DatabaseManager()
         self.pluginManager = PluginManager.shared
         self.encouragementService = EncouragementService()
@@ -40,6 +43,7 @@ public class WritersApp {
         self.templateManager = TemplateManager()
         self.documentManager = DocumentManager()
         self.issueManager = IssueManager()
+        self.kanbanManager = KanbanManager()
         self.databaseManager = DatabaseManager(databasePath: databasePath)
         self.pluginManager = PluginManager.shared
         self.encouragementService = EncouragementService()
@@ -449,6 +453,98 @@ public class WritersApp {
     /// Gets critical issues across all documents
     public func getCriticalIssues() -> [Issue] {
         return issueManager.getCriticalIssues()
+    }
+
+    // MARK: - Kanban Board Management
+
+    /// Creates a new Kanban board
+    public func createKanbanBoard(name: String, description: String = "") -> KanbanBoard {
+        let board = KanbanBoard(name: name, description: description)
+        kanbanManager.createBoard(board)
+        return board
+    }
+
+    /// Retrieves a Kanban board by ID
+    public func getKanbanBoard(id: UUID) -> KanbanBoard? {
+        return kanbanManager.getBoard(id: id)
+    }
+
+    /// Retrieves all Kanban boards
+    public func getAllKanbanBoards() -> [KanbanBoard] {
+        return kanbanManager.getAllBoards()
+    }
+
+    /// Deletes a Kanban board and all its tasks
+    public func deleteKanbanBoard(id: UUID) {
+        kanbanManager.deleteBoard(id: id)
+    }
+
+    // MARK: - Kanban Task Management
+
+    /// Creates a new task on a Kanban board
+    public func createKanbanTask(
+        boardId: UUID,
+        title: String,
+        description: String = "",
+        column: KanbanColumn = .backlog
+    ) -> KanbanTask {
+        let task = KanbanTask(
+            title: title,
+            description: description,
+            column: column,
+            boardId: boardId
+        )
+        kanbanManager.createTask(task)
+        return task
+    }
+
+    /// Retrieves a Kanban task by ID
+    public func getKanbanTask(id: UUID) -> KanbanTask? {
+        return kanbanManager.getTask(id: id)
+    }
+
+    /// Retrieves all tasks for a board
+    public func getKanbanTasks(forBoard boardId: UUID) -> [KanbanTask] {
+        return kanbanManager.getTasks(forBoard: boardId)
+    }
+
+    /// Retrieves tasks in a specific column on a board
+    public func getKanbanTasks(forBoard boardId: UUID, inColumn column: KanbanColumn) -> [KanbanTask] {
+        return kanbanManager.getTasks(forBoard: boardId, inColumn: column)
+    }
+
+    /// Searches Kanban tasks by title or description
+    public func searchKanbanTasks(query: String) -> [KanbanTask] {
+        return kanbanManager.searchTasks(query: query)
+    }
+
+    /// Deletes a Kanban task
+    public func deleteKanbanTask(id: UUID) {
+        kanbanManager.deleteTask(id: id)
+    }
+
+    /// Moves a Kanban task to a specific column
+    public func moveKanbanTask(id: UUID, toColumn column: KanbanColumn) {
+        kanbanManager.moveTask(id: id, toColumn: column)
+    }
+
+    /// Advances a Kanban task to the next column in the workflow
+    /// - Returns: The new column, or nil if the task was already in Done
+    @discardableResult
+    public func advanceKanbanTask(id: UUID) -> KanbanColumn? {
+        return kanbanManager.advanceTask(id: id)
+    }
+
+    /// Moves a Kanban task back to the previous column in the workflow
+    /// - Returns: The new column, or nil if the task was already in Backlog
+    @discardableResult
+    public func regressKanbanTask(id: UUID) -> KanbanColumn? {
+        return kanbanManager.regressTask(id: id)
+    }
+
+    /// Gets task counts by column for a board
+    public func getKanbanTaskCounts(forBoard boardId: UUID) -> [KanbanColumn: Int] {
+        return kanbanManager.getTaskCountByColumn(forBoard: boardId)
     }
 
     // MARK: - AI-Powered Features

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -448,4 +448,188 @@ final class WritersAppTests: XCTestCase {
         XCTAssertEqual(reopened?.status, .open)
         XCTAssertNil(reopened?.metadata.resolvedAt, "resolvedAt should be nil after status set to open")
     }
+
+    // MARK: - Kanban Tests
+
+    func testKanbanBoardCreationAssignsUniqueId() {
+        let board1 = app.createKanbanBoard(name: "Board One")
+        let board2 = app.createKanbanBoard(name: "Board Two")
+        XCTAssertNotEqual(board1.id, board2.id)
+    }
+
+    func testKanbanBoardRetrievedById() {
+        let board = app.createKanbanBoard(name: "My Board", description: "A test board")
+        let retrieved = app.getKanbanBoard(id: board.id)
+        XCTAssertNotNil(retrieved)
+        XCTAssertEqual(retrieved?.name, "My Board")
+        XCTAssertEqual(retrieved?.description, "A test board")
+    }
+
+    func testGetAllKanbanBoardsReturnsAllBoards() {
+        let before = app.getAllKanbanBoards().count
+        _ = app.createKanbanBoard(name: "Board A")
+        _ = app.createKanbanBoard(name: "Board B")
+        let after = app.getAllKanbanBoards()
+        XCTAssertEqual(after.count, before + 2)
+    }
+
+    func testDeleteKanbanBoardRemovesBoardAndTasks() {
+        let board = app.createKanbanBoard(name: "Delete Me")
+        _ = app.createKanbanTask(boardId: board.id, title: "Task on deleted board")
+        app.deleteKanbanBoard(id: board.id)
+        XCTAssertNil(app.getKanbanBoard(id: board.id))
+        XCTAssertTrue(app.getKanbanTasks(forBoard: board.id).isEmpty)
+    }
+
+    func testKanbanTaskCreationAssignsUniqueId() {
+        let board = app.createKanbanBoard(name: "Task Board")
+        let task1 = app.createKanbanTask(boardId: board.id, title: "Task One")
+        let task2 = app.createKanbanTask(boardId: board.id, title: "Task Two")
+        XCTAssertNotEqual(task1.id, task2.id)
+    }
+
+    func testKanbanTaskDefaultsToBacklog() {
+        let board = app.createKanbanBoard(name: "Workflow Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "New Task")
+        XCTAssertEqual(task.column, .backlog)
+    }
+
+    func testKanbanTaskRetrievedById() {
+        let board = app.createKanbanBoard(name: "Retrieval Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Findable Task", description: "Find me")
+        let retrieved = app.getKanbanTask(id: task.id)
+        XCTAssertNotNil(retrieved)
+        XCTAssertEqual(retrieved?.title, "Findable Task")
+        XCTAssertEqual(retrieved?.description, "Find me")
+    }
+
+    func testGetKanbanTasksForBoardReturnsAllTasks() {
+        let board = app.createKanbanBoard(name: "Multi-task Board")
+        _ = app.createKanbanTask(boardId: board.id, title: "Alpha")
+        _ = app.createKanbanTask(boardId: board.id, title: "Beta")
+        _ = app.createKanbanTask(boardId: board.id, title: "Gamma")
+        let tasks = app.getKanbanTasks(forBoard: board.id)
+        XCTAssertEqual(tasks.count, 3)
+    }
+
+    func testGetKanbanTasksInColumnFiltersCorrectly() {
+        let board = app.createKanbanBoard(name: "Column Filter Board")
+        _ = app.createKanbanTask(boardId: board.id, title: "Backlog Task", column: .backlog)
+        _ = app.createKanbanTask(boardId: board.id, title: "Done Task", column: .done)
+        let backlogTasks = app.getKanbanTasks(forBoard: board.id, inColumn: .backlog)
+        let doneTasks = app.getKanbanTasks(forBoard: board.id, inColumn: .done)
+        XCTAssertEqual(backlogTasks.count, 1)
+        XCTAssertEqual(doneTasks.count, 1)
+        XCTAssertEqual(backlogTasks.first?.title, "Backlog Task")
+        XCTAssertEqual(doneTasks.first?.title, "Done Task")
+    }
+
+    func testDeleteKanbanTaskRemovesTask() {
+        let board = app.createKanbanBoard(name: "Delete Task Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Temporary Task")
+        app.deleteKanbanTask(id: task.id)
+        XCTAssertNil(app.getKanbanTask(id: task.id))
+    }
+
+    func testMoveKanbanTaskBetweenColumnsUpdatesState() {
+        let board = app.createKanbanBoard(name: "Move Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Moveable Task")
+        XCTAssertEqual(task.column, .backlog)
+        app.moveKanbanTask(id: task.id, toColumn: .running)
+        let moved = app.getKanbanTask(id: task.id)
+        XCTAssertEqual(moved?.column, .running)
+    }
+
+    func testAdvanceKanbanTaskMovesForwardInWorkflow() {
+        let board = app.createKanbanBoard(name: "Advance Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Advancing Task")
+        let newColumn = app.advanceKanbanTask(id: task.id)
+        XCTAssertEqual(newColumn, .planning)
+        XCTAssertEqual(app.getKanbanTask(id: task.id)?.column, .planning)
+    }
+
+    func testAdvanceKanbanTaskThroughFullWorkflow() {
+        let board = app.createKanbanBoard(name: "Full Workflow Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Workflow Task")
+        app.advanceKanbanTask(id: task.id) // backlog → planning
+        app.advanceKanbanTask(id: task.id) // planning → running
+        app.advanceKanbanTask(id: task.id) // running → review
+        app.advanceKanbanTask(id: task.id) // review → done
+        XCTAssertEqual(app.getKanbanTask(id: task.id)?.column, .done)
+    }
+
+    func testAdvanceKanbanTaskAtDoneReturnsNil() {
+        let board = app.createKanbanBoard(name: "Done Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Done Task", column: .done)
+        let result = app.advanceKanbanTask(id: task.id)
+        XCTAssertNil(result, "Advancing from Done should return nil")
+        XCTAssertEqual(app.getKanbanTask(id: task.id)?.column, .done)
+    }
+
+    func testRegressKanbanTaskMovesBackwardInWorkflow() {
+        let board = app.createKanbanBoard(name: "Regress Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Regressing Task", column: .running)
+        let newColumn = app.regressKanbanTask(id: task.id)
+        XCTAssertEqual(newColumn, .planning)
+        XCTAssertEqual(app.getKanbanTask(id: task.id)?.column, .planning)
+    }
+
+    func testRegressKanbanTaskAtBacklogReturnsNil() {
+        let board = app.createKanbanBoard(name: "Backlog Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Backlog Task")
+        let result = app.regressKanbanTask(id: task.id)
+        XCTAssertNil(result, "Regressing from Backlog should return nil")
+        XCTAssertEqual(app.getKanbanTask(id: task.id)?.column, .backlog)
+    }
+
+    func testMoveKanbanTaskToDoneSetsCompletedAt() {
+        let board = app.createKanbanBoard(name: "Completion Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Completable Task")
+        XCTAssertNil(task.metadata.completedAt)
+        app.moveKanbanTask(id: task.id, toColumn: .done)
+        let completed = app.getKanbanTask(id: task.id)
+        XCTAssertNotNil(completed?.metadata.completedAt)
+    }
+
+    func testMoveKanbanTaskFromDoneClearsCompletedAt() {
+        let board = app.createKanbanBoard(name: "Reopen Board")
+        let task = app.createKanbanTask(boardId: board.id, title: "Reopenable Task")
+        app.moveKanbanTask(id: task.id, toColumn: .done)
+        XCTAssertNotNil(app.getKanbanTask(id: task.id)?.metadata.completedAt, "completedAt should be set on Done")
+        app.moveKanbanTask(id: task.id, toColumn: .review)
+        let moved = app.getKanbanTask(id: task.id)
+        XCTAssertNil(moved?.metadata.completedAt, "completedAt should be cleared when moved out of Done")
+    }
+
+    func testGetKanbanTaskCountsByColumn() {
+        let board = app.createKanbanBoard(name: "Count Board")
+        _ = app.createKanbanTask(boardId: board.id, title: "T1", column: .backlog)
+        _ = app.createKanbanTask(boardId: board.id, title: "T2", column: .backlog)
+        _ = app.createKanbanTask(boardId: board.id, title: "T3", column: .running)
+        let counts = app.getKanbanTaskCounts(forBoard: board.id)
+        XCTAssertEqual(counts[.backlog], 2)
+        XCTAssertEqual(counts[.running], 1)
+        XCTAssertEqual(counts[.planning], 0)
+        XCTAssertEqual(counts[.review], 0)
+        XCTAssertEqual(counts[.done], 0)
+    }
+
+    func testSearchKanbanTasksByTitle() {
+        let board = app.createKanbanBoard(name: "Search Board")
+        _ = app.createKanbanTask(boardId: board.id, title: "Write chapter one")
+        _ = app.createKanbanTask(boardId: board.id, title: "Edit draft")
+        _ = app.createKanbanTask(boardId: board.id, title: "Write synopsis")
+        let results = app.searchKanbanTasks(query: "Write")
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.allSatisfy { $0.title.localizedCaseInsensitiveContains("Write") })
+    }
+
+    func testKanbanColumnWorkflowOrder() {
+        XCTAssertNil(KanbanColumn.backlog.previous)
+        XCTAssertEqual(KanbanColumn.backlog.next, .planning)
+        XCTAssertEqual(KanbanColumn.planning.next, .running)
+        XCTAssertEqual(KanbanColumn.running.next, .review)
+        XCTAssertEqual(KanbanColumn.review.next, .done)
+        XCTAssertNil(KanbanColumn.done.next)
+    }
 }


### PR DESCRIPTION
Implements a complete Kanban board system for the writers app:

- KanbanModels.swift: KanbanColumn enum (backlog/planning/running/review/done
  with next/previous navigation), KanbanTask and KanbanBoard Codable+Identifiable
  structs, KanbanTaskMetadata with completedAt tracking
- KanbanManager.swift: Manager class with full CRUD for boards and tasks,
  column transition helpers (moveTask/advanceTask/regressTask), search, and
  per-column statistics; completedAt is kept consistent with column state
  in both moveTask and updateTask
- WritersApp.swift: Exposes KanbanManager via public facade API
  (createKanbanBoard, createKanbanTask, moveKanbanTask, advanceKanbanTask,
  regressKanbanTask, getKanbanTaskCounts, etc.)
- WritersAppTests.swift: 20 new unit tests covering board CRUD, task CRUD,
  full workflow transitions, completedAt lifecycle, column filtering, and search

https://claude.ai/code/session_015ES9rENzip5fvrsPXi6WQd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced Kanban board and task management system with customizable workflow states
* Tasks can move through workflow columns (Backlog → Planning → Running → Review → Done)
* Search and filter tasks by board and column
* Track task completion status and metadata including creation/modification dates and tags

## Tests
* Added comprehensive test coverage for Kanban board and task operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->