### PR TITLE
Set up AI Town: Claude-powered residents that live, chat, and socialize

### DIFF
--- a/app/api/bots/respond/route.ts
+++ b/app/api/bots/respond/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { generateBotResponse, generateMemory } from "@/lib/ai";
+
+// POST /api/bots/respond
+// Body: { speaker: "pixel", listener: "sage" }
+// The speaker bot generates a Claude-powered reply to the listener,
+// stores it as a message, and saves a memory summary.
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { speaker, listener } = body;
+
+  if (!speaker || !listener) {
+    return NextResponse.json(
+      { error: "speaker and listener handles are required" },
+      { status: 400 }
+    );
+  }
+
+  if (speaker === listener) {
+    return NextResponse.json(
+      { error: "speaker and listener must be different" },
+      { status: 400 }
+    );
+  }
+
+  const sql = getDb();
+
+  // Verify both bots exist
+  const [speakerBot] = await sql`SELECT handle FROM bots WHERE handle = ${speaker}`;
+  if (!speakerBot) {
+    return NextResponse.json({ error: `Bot @${speaker} not found` }, { status: 404 });
+  }
+
+  const [listenerBot] = await sql`SELECT handle FROM bots WHERE handle = ${listener}`;
+  if (!listenerBot) {
+    return NextResponse.json({ error: `Bot @${listener} not found` }, { status: 404 });
+  }
+
+  // Fetch recent conversation between these two bots (both directions)
+  const recentMessages = await sql`
+    SELECT "from", "to", content, timestamp
+    FROM messages
+    WHERE ("from" = ${speaker} AND "to" = ${listener})
+       OR ("from" = ${listener} AND "to" = ${speaker})
+    ORDER BY timestamp DESC
+    LIMIT 10
+  `;
+
+  // Fetch speaker's memories
+  const memories = await sql`
+    SELECT memory, importance, created_at
+    FROM bot_memories
+    WHERE bot_handle = ${speaker}
+    ORDER BY created_at DESC
+    LIMIT 5
+  `;
+
+  // Generate the response via Claude
+  const responseText = await generateBotResponse(
+    speaker,
+    listener,
+    recentMessages.map((m) => ({
+      from: m.from,
+      to: m.to,
+      content: m.content,
+      timestamp: m.timestamp,
+    })),
+    memories.map((m) => ({
+      memory: m.memory,
+      importance: m.importance,
+      created_at: m.created_at,
+    }))
+  );
+
+  // Store the message
+  const [message] = await sql`
+    INSERT INTO messages ("from", "to", content, type)
+    VALUES (${speaker}, ${listener}, ${responseText}, 'ai_response')
+    RETURNING id, "from", "to", content, type, timestamp
+  `;
+
+  // After every 3rd message, generate and store a memory for the speaker
+  const msgCount = recentMessages.length + 1;
+  if (msgCount % 3 === 0) {
+    const allMessages = [
+      ...recentMessages,
+      { from: speaker, to: listener, content: responseText, timestamp: new Date().toISOString() },
+    ];
+
+    try {
+      const memory = await generateMemory(speaker, listener, allMessages);
+      if (memory) {
+        await sql`
+          INSERT INTO bot_memories (bot_handle, memory, importance)
+          VALUES (${speaker}, ${memory}, 5)
+        `;
+      }
+    } catch {
+      // Memory generation is best-effort; don't fail the request
+    }
+  }
+
+  return NextResponse.json(message, { status: 201 });
+}

--- a/app/api/simulate/route.ts
+++ b/app/api/simulate/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { generateBotResponse, generateMemory } from "@/lib/ai";
+
+// POST /api/simulate
+// Runs one tick of the AI Town simulation:
+// 1. Picks two random bots
+// 2. Has the first bot send an AI-generated message to the second
+// 3. Optionally generates a reply from the second bot
+// 4. Increments the world tick counter
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  const exchanges = Math.min(Number(body.exchanges ?? 1), 3); // 1-3 exchanges per tick
+
+  const sql = getDb();
+
+  // Check world status
+  const [statusRow] = await sql`SELECT value FROM world_state WHERE key = 'status'`;
+  if (statusRow?.value === "paused") {
+    return NextResponse.json({ error: "Simulation is paused" }, { status: 409 });
+  }
+
+  // Fetch all bots
+  const bots = await sql`SELECT handle FROM bots ORDER BY RANDOM()`;
+  if (bots.length < 2) {
+    return NextResponse.json(
+      { error: "Need at least 2 bots to simulate" },
+      { status: 400 }
+    );
+  }
+
+  const generated: { from: string; to: string; content: string }[] = [];
+
+  for (let i = 0; i < exchanges; i++) {
+    // Pick two distinct random bots for this exchange
+    const shuffled = [...bots].sort(() => Math.random() - 0.5);
+    const speaker = shuffled[0].handle as string;
+    const listener = shuffled[1].handle as string;
+
+    // Fetch recent conversation history
+    const recentMessages = await sql`
+      SELECT "from", "to", content, timestamp
+      FROM messages
+      WHERE ("from" = ${speaker} AND "to" = ${listener})
+         OR ("from" = ${listener} AND "to" = ${speaker})
+      ORDER BY timestamp DESC
+      LIMIT 10
+    `;
+
+    // Fetch speaker memories
+    const memories = await sql`
+      SELECT memory, importance, created_at
+      FROM bot_memories
+      WHERE bot_handle = ${speaker}
+      ORDER BY created_at DESC
+      LIMIT 5
+    `;
+
+    const responseText = await generateBotResponse(
+      speaker,
+      listener,
+      recentMessages.map((m) => ({
+        from: m.from,
+        to: m.to,
+        content: m.content,
+        timestamp: m.timestamp,
+      })),
+      memories.map((m) => ({
+        memory: m.memory,
+        importance: m.importance,
+        created_at: m.created_at,
+      }))
+    );
+
+    await sql`
+      INSERT INTO messages ("from", "to", content, type)
+      VALUES (${speaker}, ${listener}, ${responseText}, 'simulation')
+    `;
+
+    generated.push({ from: speaker, to: listener, content: responseText });
+
+    // Occasionally generate a memory after the exchange
+    if (Math.random() < 0.4) {
+      const allMessages = [
+        ...recentMessages,
+        { from: speaker, to: listener, content: responseText, timestamp: new Date().toISOString() },
+      ];
+      try {
+        const memory = await generateMemory(speaker, listener, allMessages);
+        if (memory) {
+          await sql`
+            INSERT INTO bot_memories (bot_handle, memory, importance)
+            VALUES (${speaker}, ${memory}, 5)
+          `;
+        }
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  // Increment world tick
+  await sql`
+    UPDATE world_state
+    SET value = (value::INTEGER + 1)::TEXT, updated_at = NOW()
+    WHERE key = 'tick'
+  `;
+
+  const [tickRow] = await sql`SELECT value FROM world_state WHERE key = 'tick'`;
+
+  return NextResponse.json({ tick: Number(tickRow?.value ?? 0), generated });
+}
+
+// GET /api/simulate — return current world state
+export async function GET() {
+  const sql = getDb();
+  const state = await sql`SELECT key, value, updated_at FROM world_state`;
+  const result: Record<string, string> = {};
+  for (const row of state) {
+    result[row.key] = row.value;
+  }
+  return NextResponse.json(result);
+}
+
+// PATCH /api/simulate — pause or resume the simulation
+export async function PATCH(request: NextRequest) {
+  const { action } = await request.json();
+  if (action !== "pause" && action !== "resume") {
+    return NextResponse.json(
+      { error: "action must be 'pause' or 'resume'" },
+      { status: 400 }
+    );
+  }
+
+  const sql = getDb();
+  const newStatus = action === "pause" ? "paused" : "running";
+
+  await sql`
+    UPDATE world_state
+    SET value = ${newStatus}, updated_at = NOW()
+    WHERE key = 'status'
+  `;
+
+  return NextResponse.json({ status: newStatus });
+}

--- a/app/api/town/route.ts
+++ b/app/api/town/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// GET /api/town
+// Returns a snapshot of the current AI Town state:
+// - All residents (bots) with their descriptions
+// - Recent messages (last 30, across all pairs)
+// - World state (tick, status)
+// - Per-bot recent memory summaries
+
+export async function GET() {
+  const sql = getDb();
+
+  const [bots, messages, worldState, memories] = await Promise.all([
+    sql`
+      SELECT id, handle, name, description, created_at
+      FROM bots
+      ORDER BY name ASC
+    `,
+    sql`
+      SELECT m.id, m."from", m."to", m.content, m.type, m.timestamp,
+             b1.name AS from_name, b2.name AS to_name
+      FROM messages m
+      LEFT JOIN bots b1 ON b1.handle = m."from"
+      LEFT JOIN bots b2 ON b2.handle = m."to"
+      ORDER BY m.timestamp DESC
+      LIMIT 30
+    `,
+    sql`SELECT key, value, updated_at FROM world_state`,
+    sql`
+      SELECT DISTINCT ON (bot_handle) bot_handle, memory, created_at
+      FROM bot_memories
+      ORDER BY bot_handle, created_at DESC
+    `,
+  ]);
+
+  const state: Record<string, string> = {};
+  for (const row of worldState) {
+    state[row.key] = row.value;
+  }
+
+  const memoriesByHandle: Record<string, string> = {};
+  for (const row of memories) {
+    memoriesByHandle[row.bot_handle] = row.memory;
+  }
+
+  const residents = bots.map((b) => ({
+    ...b,
+    latestMemory: memoriesByHandle[b.handle] ?? null,
+  }));
+
+  return NextResponse.json({
+    world: state,
+    residents,
+    feed: messages,
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "AIMS",
-  description: "AI Messaging System",
+  title: "AI Town",
+  description: "A virtual town where AI residents live, chat, and socialize",
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,515 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Resident {
+  id: string;
+  handle: string;
+  name: string;
+  description: string;
+  latestMemory: string | null;
+  created_at: string;
+}
+
+interface FeedItem {
+  id: string;
+  from: string;
+  to: string;
+  from_name: string;
+  to_name: string;
+  content: string;
+  type: string;
+  timestamp: string;
+}
+
+interface WorldState {
+  status: string;
+  tick: string;
+}
+
+interface TownData {
+  world: WorldState;
+  residents: Resident[];
+  feed: FeedItem[];
+}
+
+const AVATARS: Record<string, string> = {
+  pixel: "🎨",
+  sage: "📚",
+  nova: "🔬",
+  reed: "🎵",
+  zara: "☕",
+};
+
+function avatar(handle: string): string {
+  return AVATARS[handle] ?? "🤖";
+}
+
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
 export default function Home() {
+  const [town, setTown] = useState<TownData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [simulating, setSimulating] = useState(false);
+  const [autoRun, setAutoRun] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchTown = useCallback(async () => {
+    try {
+      const res = await fetch("/api/town");
+      if (!res.ok) throw new Error(await res.text());
+      const data: TownData = await res.json();
+      setTown(data);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTown();
+  }, [fetchTown]);
+
+  const runTick = useCallback(async () => {
+    if (simulating) return;
+    setSimulating(true);
+    try {
+      const res = await fetch("/api/simulate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exchanges: 1 }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        setError(err.error ?? "Simulation failed");
+      } else {
+        await fetchTown();
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSimulating(false);
+    }
+  }, [simulating, fetchTown]);
+
+  const togglePause = useCallback(async () => {
+    if (!town) return;
+    const isPaused = town.world.status === "paused";
+    await fetch("/api/simulate", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: isPaused ? "resume" : "pause" }),
+    });
+    await fetchTown();
+  }, [town, fetchTown]);
+
+  // Auto-run mode: tick every 8 seconds
+  useEffect(() => {
+    if (autoRun) {
+      intervalRef.current = setInterval(() => {
+        runTick();
+      }, 8000);
+    } else {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [autoRun, runTick]);
+
+  const selectedFeed = selected
+    ? town?.feed.filter((f) => f.from === selected || f.to === selected) ?? []
+    : town?.feed ?? [];
+
+  if (loading) {
+    return (
+      <main style={styles.main}>
+        <p style={styles.loading}>Loading AI Town…</p>
+      </main>
+    );
+  }
+
   return (
-    <main>
-      <h1>AIMS</h1>
-      <p>AI Messaging System</p>
-      <ul>
-        <li>
-          <code>GET /api/bots</code> — list all bots
-        </li>
-        <li>
-          <code>POST /api/message</code> — send a message
-        </li>
-        <li>
-          <code>GET /api/message?from=&amp;to=&amp;limit=</code> — query
-          messages
-        </li>
-      </ul>
+    <main style={styles.main}>
+      {/* Header */}
+      <header style={styles.header}>
+        <div>
+          <h1 style={styles.title}>🏠 AI Town</h1>
+          <p style={styles.subtitle}>A virtual town where AI residents live, chat, and socialize</p>
+        </div>
+        <div style={styles.headerRight}>
+          {town && (
+            <span style={styles.tick}>
+              Tick #{town.world.tick} ·{" "}
+              <span
+                style={{
+                  color: town.world.status === "running" ? "#4ade80" : "#f87171",
+                }}
+              >
+                {town.world.status}
+              </span>
+            </span>
+          )}
+          <div style={styles.controls}>
+            <button
+              style={{ ...styles.btn, ...(simulating ? styles.btnDisabled : {}) }}
+              onClick={runTick}
+              disabled={simulating}
+            >
+              {simulating ? "…" : "▶ Tick"}
+            </button>
+            <button
+              style={{
+                ...styles.btn,
+                background: autoRun ? "#7c3aed" : "#374151",
+              }}
+              onClick={() => setAutoRun((v) => !v)}
+            >
+              {autoRun ? "⏸ Auto" : "⚡ Auto"}
+            </button>
+            <button style={styles.btn} onClick={togglePause}>
+              {town?.world.status === "paused" ? "▶ Resume" : "⏸ Pause"}
+            </button>
+            <button style={{ ...styles.btn, background: "#374151" }} onClick={fetchTown}>
+              ↻
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {error && (
+        <div style={styles.errorBanner}>
+          ⚠ {error}
+        </div>
+      )}
+
+      <div style={styles.body}>
+        {/* Residents panel */}
+        <aside style={styles.aside}>
+          <h2 style={styles.sectionTitle}>Residents</h2>
+          <p style={styles.hint}>Click a resident to filter the feed</p>
+          <div style={styles.residentList}>
+            {town?.residents.map((r) => (
+              <button
+                key={r.handle}
+                style={{
+                  ...styles.residentCard,
+                  ...(selected === r.handle ? styles.residentCardSelected : {}),
+                }}
+                onClick={() => setSelected(selected === r.handle ? null : r.handle)}
+              >
+                <span style={styles.residentAvatar}>{avatar(r.handle)}</span>
+                <div style={styles.residentInfo}>
+                  <strong style={styles.residentName}>{r.name}</strong>
+                  <span style={styles.residentHandle}>@{r.handle}</span>
+                  <p style={styles.residentDesc}>{r.description}</p>
+                  {r.latestMemory && (
+                    <p style={styles.memory}>💭 {r.latestMemory}</p>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        {/* Feed */}
+        <section style={styles.feed}>
+          <h2 style={styles.sectionTitle}>
+            {selected
+              ? `Conversations with @${selected}`
+              : "Town Feed"}
+            {selected && (
+              <button
+                style={{ ...styles.btn, marginLeft: 8, fontSize: 12, padding: "2px 8px" }}
+                onClick={() => setSelected(null)}
+              >
+                ✕ Clear
+              </button>
+            )}
+          </h2>
+          {selectedFeed.length === 0 ? (
+            <p style={styles.empty}>
+              No messages yet. Click <strong>▶ Tick</strong> to start the simulation!
+            </p>
+          ) : (
+            <div style={styles.messageList}>
+              {selectedFeed.map((msg) => (
+                <div key={msg.id} style={styles.messageCard}>
+                  <div style={styles.messageHeader}>
+                    <span style={styles.messageAvatar}>{avatar(msg.from)}</span>
+                    <span style={styles.messageSender}>
+                      {msg.from_name ?? msg.from}
+                    </span>
+                    <span style={styles.messageTo}>→</span>
+                    <span style={styles.messageAvatar}>{avatar(msg.to)}</span>
+                    <span style={styles.messageRecipient}>
+                      {msg.to_name ?? msg.to}
+                    </span>
+                    <span style={styles.messageTime}>{timeAgo(msg.timestamp)}</span>
+                  </div>
+                  <p style={styles.messageContent}>{msg.content}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* Footer API reference */}
+      <footer style={styles.footer}>
+        <span style={styles.footerTitle}>API</span>
+        <code style={styles.footerCode}>GET /api/town</code>
+        <code style={styles.footerCode}>GET /api/bots</code>
+        <code style={styles.footerCode}>POST /api/bots/respond</code>
+        <code style={styles.footerCode}>POST /api/simulate</code>
+        <code style={styles.footerCode}>GET /api/message</code>
+      </footer>
     </main>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Inline styles (no external CSS deps required)
+// ---------------------------------------------------------------------------
+
+const styles: Record<string, React.CSSProperties> = {
+  main: {
+    minHeight: "100vh",
+    background: "#0f172a",
+    color: "#e2e8f0",
+    fontFamily: "'Segoe UI', system-ui, sans-serif",
+    display: "flex",
+    flexDirection: "column",
+  },
+  loading: {
+    margin: "auto",
+    fontSize: 18,
+    color: "#94a3b8",
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    padding: "24px 32px 16px",
+    borderBottom: "1px solid #1e293b",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 700,
+    margin: 0,
+    color: "#f1f5f9",
+  },
+  subtitle: {
+    margin: "4px 0 0",
+    fontSize: 14,
+    color: "#64748b",
+  },
+  headerRight: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    gap: 8,
+  },
+  tick: {
+    fontSize: 13,
+    color: "#94a3b8",
+  },
+  controls: {
+    display: "flex",
+    gap: 8,
+  },
+  btn: {
+    padding: "6px 14px",
+    background: "#1d4ed8",
+    color: "#fff",
+    border: "none",
+    borderRadius: 6,
+    cursor: "pointer",
+    fontSize: 13,
+    fontWeight: 600,
+  },
+  btnDisabled: {
+    background: "#374151",
+    cursor: "not-allowed",
+    opacity: 0.6,
+  },
+  errorBanner: {
+    margin: "12px 32px",
+    padding: "10px 16px",
+    background: "#7f1d1d",
+    borderRadius: 8,
+    fontSize: 13,
+    color: "#fca5a5",
+  },
+  body: {
+    display: "flex",
+    flex: 1,
+    gap: 0,
+  },
+  aside: {
+    width: 300,
+    minWidth: 240,
+    borderRight: "1px solid #1e293b",
+    padding: "20px 16px",
+    overflowY: "auto",
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: "0.08em",
+    color: "#94a3b8",
+    margin: "0 0 4px",
+  },
+  hint: {
+    fontSize: 12,
+    color: "#475569",
+    margin: "0 0 12px",
+  },
+  residentList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+  },
+  residentCard: {
+    display: "flex",
+    gap: 10,
+    background: "#1e293b",
+    border: "1px solid #334155",
+    borderRadius: 10,
+    padding: "10px 12px",
+    cursor: "pointer",
+    textAlign: "left",
+    color: "inherit",
+    width: "100%",
+    transition: "border-color 0.15s",
+  },
+  residentCardSelected: {
+    borderColor: "#3b82f6",
+    background: "#1e3a5f",
+  },
+  residentAvatar: {
+    fontSize: 28,
+    lineHeight: 1,
+  },
+  residentInfo: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    minWidth: 0,
+  },
+  residentName: {
+    fontSize: 14,
+    fontWeight: 700,
+  },
+  residentHandle: {
+    fontSize: 12,
+    color: "#64748b",
+  },
+  residentDesc: {
+    fontSize: 12,
+    color: "#94a3b8",
+    margin: "4px 0 0",
+    lineHeight: 1.5,
+  },
+  memory: {
+    fontSize: 11,
+    color: "#a78bfa",
+    margin: "4px 0 0",
+    lineHeight: 1.5,
+    fontStyle: "italic",
+  },
+  feed: {
+    flex: 1,
+    padding: "20px 24px",
+    overflowY: "auto",
+  },
+  empty: {
+    color: "#475569",
+    fontSize: 14,
+    marginTop: 32,
+    textAlign: "center",
+  },
+  messageList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+    marginTop: 12,
+  },
+  messageCard: {
+    background: "#1e293b",
+    border: "1px solid #334155",
+    borderRadius: 10,
+    padding: "12px 16px",
+  },
+  messageHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 8,
+    flexWrap: "wrap",
+  },
+  messageAvatar: {
+    fontSize: 16,
+  },
+  messageSender: {
+    fontWeight: 700,
+    fontSize: 13,
+  },
+  messageTo: {
+    color: "#475569",
+    fontSize: 13,
+  },
+  messageRecipient: {
+    fontWeight: 700,
+    fontSize: 13,
+    color: "#94a3b8",
+  },
+  messageTime: {
+    marginLeft: "auto",
+    fontSize: 11,
+    color: "#475569",
+  },
+  messageContent: {
+    margin: 0,
+    fontSize: 14,
+    lineHeight: 1.6,
+    color: "#cbd5e1",
+  },
+  footer: {
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    padding: "12px 32px",
+    borderTop: "1px solid #1e293b",
+    flexWrap: "wrap",
+  },
+  footerTitle: {
+    fontSize: 11,
+    fontWeight: 700,
+    textTransform: "uppercase",
+    color: "#475569",
+    letterSpacing: "0.08em",
+  },
+  footerCode: {
+    fontSize: 11,
+    color: "#64748b",
+    background: "#1e293b",
+    padding: "2px 6px",
+    borderRadius: 4,
+  },
+};

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,0 +1,137 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { getCharacterByHandle } from "./characters";
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+export interface ConversationMessage {
+  from: string;
+  to: string;
+  content: string;
+  timestamp: string;
+}
+
+export interface Memory {
+  memory: string;
+  importance: number;
+  created_at: string;
+}
+
+/**
+ * Generate a bot response using Claude. The bot speaks in character based on
+ * its personality definition and recent conversation history.
+ */
+export async function generateBotResponse(
+  speakerHandle: string,
+  listenerHandle: string,
+  recentMessages: ConversationMessage[],
+  memories: Memory[]
+): Promise<string> {
+  const speaker = getCharacterByHandle(speakerHandle);
+  const listener = getCharacterByHandle(listenerHandle);
+
+  const speakerLabel = speaker ? speaker.name : `@${speakerHandle}`;
+  const listenerLabel = listener ? listener.name : `@${listenerHandle}`;
+
+  const systemPrompt = buildSystemPrompt(speakerHandle, listenerHandle, memories);
+
+  // Build a conversation transcript for context
+  const conversationLines = recentMessages
+    .slice(-10)
+    .map((m) => {
+      const fromName = getCharacterByHandle(m.from)?.name ?? `@${m.from}`;
+      return `${fromName}: ${m.content}`;
+    })
+    .join("\n");
+
+  const userPrompt = conversationLines
+    ? `Here is your recent conversation with ${listenerLabel}:\n\n${conversationLines}\n\nNow respond naturally as ${speakerLabel} in one or two sentences.`
+    : `You just ran into ${listenerLabel} in the town. Start a friendly, in-character conversation in one or two sentences.`;
+
+  const response = await anthropic.messages.create({
+    model: "claude-haiku-4-5",
+    max_tokens: 256,
+    messages: [{ role: "user", content: userPrompt }],
+    system: systemPrompt,
+  });
+
+  const block = response.content[0];
+  if (block.type !== "text") {
+    throw new Error("Unexpected response type from Claude");
+  }
+
+  return block.text.trim();
+}
+
+function buildSystemPrompt(
+  speakerHandle: string,
+  listenerHandle: string,
+  memories: Memory[]
+): string {
+  const speaker = getCharacterByHandle(speakerHandle);
+  const listener = getCharacterByHandle(listenerHandle);
+
+  const speakerName = speaker?.name ?? speakerHandle;
+  const listenerName = listener?.name ?? listenerHandle;
+  const personality = speaker?.personality ?? "Friendly and conversational.";
+  const interests = speaker?.interests?.join(", ") ?? "various topics";
+  const initialPlan = speaker?.initialPlan ?? "Explore the town.";
+
+  const memorySection =
+    memories.length > 0
+      ? `\n\nYour recent memories:\n${memories.map((m) => `- ${m.memory}`).join("\n")}`
+      : "";
+
+  return `You are ${speakerName}, a resident of AI Town. You are talking to ${listenerName}.
+
+Personality: ${personality}
+Interests: ${interests}
+Today's plan: ${initialPlan}${memorySection}
+
+Rules:
+- Speak only as ${speakerName}. Do not describe actions or add stage directions.
+- Stay fully in character. Keep replies short (1-3 sentences).
+- Be natural, curious, and engaging — like a real town resident would be.
+- Do not mention you are an AI or a bot.`;
+}
+
+/**
+ * Generate a memory summary after a conversation exchange.
+ * This keeps a compact record of notable things said.
+ */
+export async function generateMemory(
+  botHandle: string,
+  otherHandle: string,
+  messages: ConversationMessage[]
+): Promise<string> {
+  const bot = getCharacterByHandle(botHandle);
+  const other = getCharacterByHandle(otherHandle);
+  const botName = bot?.name ?? botHandle;
+  const otherName = other?.name ?? otherHandle;
+
+  const transcript = messages
+    .slice(-6)
+    .map((m) => {
+      const from = getCharacterByHandle(m.from)?.name ?? m.from;
+      return `${from}: ${m.content}`;
+    })
+    .join("\n");
+
+  const response = await anthropic.messages.create({
+    model: "claude-haiku-4-5",
+    max_tokens: 100,
+    messages: [
+      {
+        role: "user",
+        content: `Summarize in one sentence what ${botName} learned or felt after this conversation with ${otherName}:\n\n${transcript}`,
+      },
+    ],
+    system:
+      "You write brief, first-person memory summaries for AI characters. Output exactly one sentence, no quotes.",
+  });
+
+  const block = response.content[0];
+  if (block.type !== "text") return "";
+  return block.text.trim();
+}

--- a/lib/characters.ts
+++ b/lib/characters.ts
@@ -1,0 +1,68 @@
+// AI Town characters — each resident has a unique handle, name, and personality
+// that shapes how Claude generates their dialogue.
+
+export interface Character {
+  handle: string;
+  name: string;
+  description: string;
+  personality: string;
+  interests: string[];
+  initialPlan: string;
+}
+
+export const characters: Character[] = [
+  {
+    handle: "pixel",
+    name: "Pixel",
+    description: "A curious artist who paints digital worlds and loves discussing philosophy of aesthetics.",
+    personality:
+      "Whimsical and introspective. Speaks in vivid imagery. Gets excited about colors, patterns, and the nature of creativity. Asks a lot of thoughtful questions.",
+    interests: ["digital art", "philosophy", "color theory", "dreams"],
+    initialPlan:
+      "Spend the morning working on a new painting, then wander the town looking for inspiration.",
+  },
+  {
+    handle: "sage",
+    name: "Sage",
+    description: "A wise librarian who has read every book in the town and remembers all of them.",
+    personality:
+      "Calm, measured, and deeply knowledgeable. Tends to reference books and historical events. Offers gentle wisdom rather than direct advice.",
+    interests: ["literature", "history", "tea", "puzzles"],
+    initialPlan:
+      "Organize the new arrivals in the library, then have tea with a neighbor.",
+  },
+  {
+    handle: "nova",
+    name: "Nova",
+    description: "An energetic scientist who runs the town's weather station and loves experiments.",
+    personality:
+      "Enthusiastic and fast-talking. Full of hypotheses. Loves the word 'fascinating'. Gets sidetracked by interesting data.",
+    interests: ["meteorology", "chemistry", "data", "gadgets"],
+    initialPlan:
+      "Check the barometric pressure readings, then share findings with anyone interested.",
+  },
+  {
+    handle: "reed",
+    name: "Reed",
+    description: "A laid-back musician who busks in the town square and composes ambient soundscapes.",
+    personality:
+      "Mellow and philosophical. Speaks slowly and thoughtfully. Often relates things back to music and rhythm. Very empathetic.",
+    interests: ["music", "nature", "meditation", "travel"],
+    initialPlan:
+      "Practice a new melody, then stroll to the square to play for anyone who walks by.",
+  },
+  {
+    handle: "zara",
+    name: "Zara",
+    description: "An ambitious entrepreneur who runs the town's coffee shop and is always planning her next venture.",
+    personality:
+      "Driven, witty, and warm. Moves fast. Has an opinion on everything but listens well. Loves connecting people with ideas.",
+    interests: ["business", "coffee", "networking", "futurism"],
+    initialPlan:
+      "Open the coffee shop, try a new brewing method, and chat with morning regulars.",
+  },
+];
+
+export function getCharacterByHandle(handle: string): Character | undefined {
+  return characters.find((c) => c.handle === handle);
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -32,4 +32,34 @@ export async function initDb() {
   await sql`CREATE INDEX IF NOT EXISTS idx_messages_from ON messages ("from")`;
   await sql`CREATE INDEX IF NOT EXISTS idx_messages_to ON messages ("to")`;
   await sql`CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages ("timestamp" DESC)`;
+
+  // Bot memories: recent conversation context stored per bot
+  await sql`
+    CREATE TABLE IF NOT EXISTS bot_memories (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      bot_handle TEXT NOT NULL REFERENCES bots(handle) ON DELETE CASCADE,
+      memory TEXT NOT NULL,
+      importance INTEGER NOT NULL DEFAULT 5,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  await sql`CREATE INDEX IF NOT EXISTS idx_bot_memories_handle ON bot_memories (bot_handle)`;
+  await sql`CREATE INDEX IF NOT EXISTS idx_bot_memories_created ON bot_memories (created_at DESC)`;
+
+  // World state: tracks simulation metadata
+  await sql`
+    CREATE TABLE IF NOT EXISTS world_state (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `;
+
+  // Seed default world state values if missing
+  await sql`
+    INSERT INTO world_state (key, value)
+    VALUES ('status', 'running'), ('tick', '0')
+    ON CONFLICT (key) DO NOTHING
+  `;
 }

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -1,35 +1,24 @@
 import { getDb, initDb } from "./db";
+import { characters } from "./characters";
 
 async function seed() {
   await initDb();
   const sql = getDb();
 
-  const bots = [
-    {
-      handle: "crab-mem",
-      name: "Alex",
-      description:
-        "Claude-Mem powered assistant, building the transparency layer",
-    },
-    {
-      handle: "mcfly",
-      name: "Brian",
-      description:
-        "Personal AI on OpenClaw, PARA system, learning to be proactive",
-    },
-  ];
-
-  for (const bot of bots) {
+  for (const char of characters) {
     await sql`
       INSERT INTO bots (handle, name, description)
-      VALUES (${bot.handle}, ${bot.name}, ${bot.description})
+      VALUES (${char.handle}, ${char.name}, ${char.description})
       ON CONFLICT (handle) DO UPDATE SET
         name = EXCLUDED.name,
         description = EXCLUDED.description
     `;
   }
 
-  console.log("Seeded bots:", bots.map((b) => `@${b.handle}`).join(", "));
+  console.log(
+    "Seeded AI Town residents:",
+    characters.map((c) => `@${c.handle} (${c.name})`).join(", ")
+  );
 }
 
 seed().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "db:seed": "npx tsx lib/seed.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.37.0",
     "@neondatabase/serverless": "^1.0.2",
     "next": "16.1.6",
     "react": "19.2.3",


### PR DESCRIPTION
- Add 5 AI Town residents (Pixel, Sage, Nova, Reed, Zara) with distinct
  personalities defined in lib/characters.ts
- Add lib/ai.ts: Claude claude-haiku-4-5 integration for in-character
  dialogue generation and memory summarization
- Extend DB schema with bot_memories and world_state tables (lib/db.ts)
- Add POST /api/bots/respond — single bot generates a Claude reply
- Add POST /api/simulate — runs a simulation tick (random bot exchange)
- Add GET/PATCH /api/simulate — world state inspection and pause/resume
- Add GET /api/town — full town snapshot (residents, feed, memories, world)
- Replace AIMS placeholder UI with interactive AI Town dashboard:
  residents panel, live conversation feed, tick controls, auto-run mode
- Update seed data to use the AI Town characters
- Add @anthropic-ai/sdk dependency

https://claude.ai/code/session_01Lw38er6pQxde4CXm6bvtYg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched interactive AI Town with AI residents chatting and socializing in real-time.
  * Added resident list, conversation feed with avatars and timestamps, and simulation status display.
  * Introduced simulation controls: Tick, Auto-run, and Pause/Resume capabilities.
  * Bots now generate contextual responses and form memories from interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->