### PR TITLE
Add explicit least-privilege permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Set `permissions: contents: read` at the workflow level so the Swift
build/test job only has the minimum access it needs (repository checkout).
This removes the implicit all-permissions default, following GitHub's
security best practice of least privilege for CI workflows.

https://claude.ai/code/session_019bSxq5gy711ejZfeeWsqGV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->