### PR TITLE
Add Claude Code skills and document extension architecture

### DIFF
--- a/.claude/skills/add-ai-feature.md
+++ b/.claude/skills/add-ai-feature.md
@@ -1,0 +1,115 @@
+---
+name: add-ai-feature
+description: Implement a new AI-powered writing feature in the friendly-outlaw app. Invoke when asked to add or extend an AI capability (e.g. "add a chapter outline generator", "add a tone changer AI feature").
+---
+
+# Add a New AI Feature
+
+Follow these steps to add a new AI-assisted writing capability.
+
+## Step 1 — Consult the knowledge advisor
+
+Before writing any code, call the `knowledge-advisor` subagent:
+
+> "I am about to add an AI feature: <brief description>. What standards apply?"
+
+This returns the mandatory rules from `swift.json`, `architecture.json`, `security.json`, and `testing.json`.
+
+## Step 2 — Add the assistance type (if needed)
+
+File: `Sources/WritersApp/Models/AIModels.swift`
+
+If the feature represents a new _kind_ of assistance, add a case to `AIAssistanceType`:
+
+```swift
+// Simple case
+case myNewFeature
+
+// Parameterised case (only if the variant drives a meaningfully different prompt)
+case changeTone(WritingTone)
+```
+
+Use `custom(String)` for one-off requests rather than adding a permanent case.
+
+## Step 3 — Implement the method on AIService
+
+File: `Sources/WritersApp/Services/AIService.swift`
+
+Add a focused `async throws` method following the service pattern:
+
+```swift
+/// One-sentence description of what this method does.
+public func myNewFeature(text: String, context: String? = nil) async throws -> <ReturnType> {
+    let systemPrompt = """
+        <Concise system instruction for Claude. No hardcoded keys or secrets.>
+        """
+
+    let userContent = context.map { "\($0)\n\n\(text)" } ?? text
+
+    let response = try await sendMessage(
+        systemPrompt: systemPrompt,
+        userContent: userContent
+    )
+    return response  // or parse into a typed result
+}
+```
+
+Rules:
+- Method must be `public` and `async throws`
+- Use `AIServiceError` for typed error propagation
+- Never hardcode the API key — it comes from `AIConfiguration`
+- Only `AIService` makes network calls (no network in managers or models)
+- Include the `anthropic-version: 2023-06-01` header (handled by `sendMessage`)
+
+## Step 4 — Expose on WritersApp facade (if user-facing)
+
+File: `Sources/WritersApp/WritersApp.swift`
+
+Add a public convenience method that guards on `isAIEnabled` and delegates to `aiService`:
+
+```swift
+public func myNewFeature(documentId: UUID, context: String? = nil) async throws -> <ReturnType> {
+    guard isAIEnabled, let aiService else { throw AIError.aiNotEnabled }
+    guard let document = documentManager.getDocument(id: documentId) else {
+        throw AIError.documentNotFound
+    }
+    return try await aiService.myNewFeature(text: document.content, context: context)
+}
+```
+
+## Step 5 — Add a CLI option (optional)
+
+File: `Sources/WritersAppCLI/main.swift`
+
+If the feature should be reachable from the interactive CLI, add a numbered menu option in the AI assistance section and wire it to the new facade method.
+
+## Step 6 — Write tests
+
+File: `Tests/WritersAppTests/WritersAppTests.swift`
+
+Add a test following the project convention (no live API calls — test that the method throws `AIError.aiNotEnabled` when AI is disabled, and test any synchronous parsing logic):
+
+```swift
+func testMyNewFeatureThrowsWhenAIDisabled() async throws {
+    let app = WritersApp()
+    let doc = app.createBlankDocument(title: "Test", category: .article)
+    do {
+        _ = try await app.myNewFeature(documentId: doc.id)
+        XCTFail("Expected AIError.aiNotEnabled")
+    } catch AIError.aiNotEnabled {
+        // expected
+    }
+}
+```
+
+## Step 7 — Run the full test suite
+
+```bash
+swift test
+```
+
+Use the `test-runner` subagent if you want a concise pass/fail report.
+
+## Step 8 — Run the code reviewer
+
+Use the `swift-code-reviewer` subagent on any modified `.swift` files to catch style issues before committing.

--- a/.claude/skills/add-template.md
+++ b/.claude/skills/add-template.md
@@ -1,0 +1,59 @@
+---
+name: add-template
+description: Add a new writing template to the friendly-outlaw app. Invoke when asked to create or add a template (e.g. "add a screenplay template", "create a new blog post template").
+---
+
+# Add a New Writing Template
+
+Follow these steps to add a new writing template to the app.
+
+## Step 1 — Decide the template properties
+
+Collect:
+- **Title**: human-readable name (e.g. "Mystery Novel")
+- **Category**: one of `TemplateCategory` cases — `novel`, `shortStory`, `screenplay`, `blogPost`, `article`, `essay`, `poetry`, `businessLetter`, `proposal`, `resume`, `other`
+- **Description**: one sentence describing the template
+- **Content**: the full template body using `{{placeholder_key}}` syntax for variable parts
+- **Placeholders**: list each key, its display label, and whether it is required
+
+Placeholder rules:
+- Keys must be `{{snake_case}}`
+- Aim for 3–7 placeholders per template (not too few to be generic, not too many to be tedious)
+- Mark truly optional sections with `isRequired: false`
+
+## Step 2 — Edit TemplateManager.swift
+
+File: `Sources/WritersApp/Services/TemplateManager.swift`
+
+Inside `loadDefaultTemplates()`, append a new `Template(...)` initialiser following the existing pattern:
+
+```swift
+templates.append(Template(
+    title: "<Title>",
+    content: """
+        <template body with {{placeholders}}>
+        """,
+    category: .<category>,
+    description: "<one-sentence description>",
+    placeholders: [
+        Placeholder(key: "<key>", displayName: "<Label>", isRequired: true),
+        // ... more placeholders
+    ]
+))
+```
+
+## Step 3 — Verify placeholder substitution
+
+Run a quick mental check: every `{{key}}` in `content` must have a matching `Placeholder` entry with the same `key`. Mismatches cause silent no-ops at runtime.
+
+## Step 4 — Run the test suite
+
+```bash
+swift test
+```
+
+All existing tests must continue to pass. If you added a template that changes the count returned by `getAllTemplates()`, update the assertion in `WritersAppTests.swift`.
+
+## Step 5 — Use the template-designer agent for complex templates
+
+If the template is long or the placeholder design is unclear, delegate to the `template-designer` subagent first, then apply its output here.

--- a/.claude/skills/add-version-control-op.md
+++ b/.claude/skills/add-version-control-op.md
@@ -1,0 +1,94 @@
+---
+name: add-version-control-op
+description: Add a new version control operation to the DoltVersionControlService. Invoke when asked to extend branch/commit/merge/diff/time-travel capabilities.
+---
+
+# Add a Version Control Operation
+
+The friendly-outlaw app uses a Git-inspired document version control system backed by SQLite. Follow these steps to extend it.
+
+## Architecture recap
+
+```
+DoltVersionControlService   ← business logic (Sources/WritersApp/Services/)
+        │
+        └── DatabaseManager ← SQLite persistence (Sources/WritersApp/Services/)
+                │
+                └── VersionControl models (Sources/WritersApp/Models/VersionControl.swift)
+```
+
+Key types: `VCBranch`, `VCCommit`, `VCDocumentSnapshot`, `VCDiff`, `VCMergeResult`
+
+## Step 1 — Define model types (if needed)
+
+File: `Sources/WritersApp/Models/VersionControl.swift`
+
+Add any new structs or enums. Ensure they conform to `Codable` and `Identifiable` (UUID `id`).
+
+```swift
+public struct MyNewType: Codable, Identifiable {
+    public let id: UUID
+    // ...
+}
+```
+
+## Step 2 — Add persistence to DatabaseManager (if new data needs storing)
+
+File: `Sources/WritersApp/Services/DatabaseManager.swift`
+
+- Add `CREATE TABLE IF NOT EXISTS` in `setupSchema()`
+- Add CRUD methods following existing patterns (use `CSQLite` directly, no ORM)
+- Use `DatabaseError` for typed error propagation
+- Never execute raw user strings — use `sqlite3_bind_*` for parameters
+
+## Step 3 — Implement the operation on DoltVersionControlService
+
+File: `Sources/WritersApp/Services/DoltVersionControlService.swift`
+
+```swift
+/// One-sentence description.
+public func myOperation(/* params */) throws -> ReturnType {
+    guard isInitialized else { throw VersionControlError.notInitialized }
+    // implementation
+}
+```
+
+Throw `VersionControlError` cases for known failure modes. Add new cases to the enum in `VersionControl.swift` if needed.
+
+## Step 4 — Expose on WritersApp facade (if user-facing)
+
+File: `Sources/WritersApp/WritersApp.swift`
+
+Delegate to `versionControl`:
+
+```swift
+public func myOperation(/* params */) throws -> ReturnType {
+    return try versionControl.myOperation(/* params */)
+}
+```
+
+## Step 5 — Write tests using an in-memory database
+
+File: `Tests/WritersAppTests/WritersAppTests.swift`
+
+Always use `:memory:` for test isolation:
+
+```swift
+func testMyOperation() throws {
+    let db = DatabaseManager(databasePath: ":memory:")
+    let vc = DoltVersionControlService(databaseManager: db)
+    try vc.initializeDefaultBranch()
+
+    // arrange
+    // act
+    // assert
+}
+```
+
+## Step 6 — Build and test
+
+```bash
+swift test
+```
+
+Or invoke the `build-and-test` skill.

--- a/.claude/skills/build-and-test.md
+++ b/.claude/skills/build-and-test.md
@@ -1,0 +1,48 @@
+---
+name: build-and-test
+description: Build the project and run the full test suite. Use before committing changes or when verifying the project is in a clean state.
+---
+
+# Build and Test
+
+Run the following commands in order.
+
+## 1. Build (debug)
+
+```bash
+swift build 2>&1
+```
+
+A clean build output ends with `Build complete!`. Compiler errors appear as `error:` lines — fix them before proceeding.
+
+## 2. Run tests
+
+```bash
+swift test 2>&1
+```
+
+All tests should pass. The output ends with:
+```
+Test Suite 'All tests' passed ...
+```
+
+If tests fail, use the `swift-debugger` subagent to diagnose, or the `test-runner` subagent for a concise failure summary.
+
+## 3. Release build (optional — before tagging a release)
+
+```bash
+swift build -c release 2>&1
+```
+
+## Common failure patterns
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `missing sqlite3` / `CSQLite` link error | `libsqlite3-dev` not installed | `apt-get install libsqlite3-dev pkg-config` |
+| `cannot find type 'X' in scope` | New type not imported or file not in target | Check `Package.swift` target sources |
+| Test count assertion fails | Template count changed | Update the `XCTAssertEqual` in `WritersAppTests.swift` |
+| `error: expression is ambiguous` | Enum case added without updating switch exhaustiveness | Add the missing `case` to every `switch` on that enum |
+
+## Tip
+
+The `session-start.sh` hook runs `swift build` automatically at the start of each Claude Code web session, so dependencies and build artifacts are usually already cached.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,6 +472,63 @@ Run with: `swift test`
 |----------|---------|
 | `ANTHROPIC_API_KEY` | Claude API key for AI features |
 
+## Claude Code Extensions
+
+The `.claude/` directory organises all Claude Code extensions for this project.
+
+```
+.claude/
+├── settings.json          # Hooks registration + tool permissions
+├── hooks/
+│   └── session-start.sh   # SessionStart hook — installs deps, builds, installs plugins
+├── agents/                # Subagents (isolated workers with their own context)
+│   ├── knowledge-advisor.md
+│   ├── swift-code-reviewer.md
+│   ├── swift-debugger.md
+│   ├── template-designer.md
+│   └── test-runner.md
+├── skills/                # Skills (reusable workflows that run in the current context)
+│   ├── add-template.md
+│   ├── add-ai-feature.md
+│   ├── build-and-test.md
+│   └── add-version-control-op.md
+└── knowledge/             # Structured standards as JSON (used by knowledge-advisor)
+    ├── index.json
+    ├── swift.json
+    ├── architecture.json
+    ├── security.json
+    ├── templates.json
+    └── testing.json
+```
+
+### When to use each extension
+
+| Extension | Purpose | How to invoke |
+|-----------|---------|---------------|
+| **Subagent** (`.claude/agents/`) | Isolated worker — does research or runs tests without filling your context | Delegate tasks: "Use the swift-code-reviewer agent on this file" |
+| **Skill** (`.claude/skills/`) | Step-by-step workflow that runs in your current session | Say: "Use the add-template skill" or ask Claude to add a template |
+| **Hook** (`.claude/hooks/`) | Deterministic script on a lifecycle event (no LLM involved) | Runs automatically on `SessionStart` |
+| **MCP** (`.mcp.json`) | External service connections (browser, Gemini) | Available as tools throughout the session |
+
+### Available Subagents
+
+| Agent | When to use |
+|-------|-------------|
+| `knowledge-advisor` | Before any Swift code change — returns applicable standards |
+| `swift-code-reviewer` | After modifying `.swift` files — checks quality and conventions |
+| `swift-debugger` | On build errors, crashes, or test failures |
+| `template-designer` | When designing a complex new writing template |
+| `test-runner` | To get a concise pass/fail summary of `swift test` |
+
+### Available Skills
+
+| Skill | When to use |
+|-------|-------------|
+| `add-template` | Adding a new writing template to `TemplateManager` |
+| `add-ai-feature` | Implementing a new AI-assisted writing capability |
+| `build-and-test` | Building the project and running the full test suite |
+| `add-version-control-op` | Extending `DoltVersionControlService` with new operations |
+
 ## Knowledge System
 
 Project standards live in `.claude/knowledge/` as structured JSON files. Before making any code change, consult the relevant files or use the **knowledge-advisor** subagent to retrieve applicable rules automatically.


### PR DESCRIPTION
Introduces a .claude/skills/ directory with four reusable workflow skills:
- add-template: step-by-step guide for adding writing templates
- add-ai-feature: guide for implementing new AI-assisted features
- build-and-test: build + test commands with common failure patterns
- add-version-control-op: guide for extending DoltVersionControlService

Updates CLAUDE.md with a new "Claude Code Extensions" section that maps all
extension types (subagents, skills, hooks, MCP) to their location and use case,
and provides quick-reference tables for all available agents and skills.

https://claude.ai/code/session_013c3XqeCazELRhe5fCshXkG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal development guidance documentation covering processes for adding AI-powered features, creating writing templates, extending version control operations, and building and testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->