### PR TITLE
Add Ragie document retrieval integration

### DIFF
--- a/Sources/WritersApp/Models/RagieModels.swift
+++ b/Sources/WritersApp/Models/RagieModels.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+// MARK: - Ragie Configuration
+
+/// Configuration for the Ragie document retrieval service
+public struct RagieConfiguration: Codable {
+    public let apiKey: String
+    public let topK: Int
+    public let rerank: Bool
+
+    public init(
+        apiKey: String,
+        topK: Int = 8,
+        rerank: Bool = false
+    ) {
+        self.apiKey = apiKey
+        self.topK = topK
+        self.rerank = rerank
+    }
+}
+
+// MARK: - Ragie Document
+
+/// A document stored in Ragie
+public struct RagieDocument: Codable {
+    public let id: String
+    public let status: String
+    public let name: String?
+    public let chunkCount: Int?
+
+    public var isReady: Bool {
+        return status == "ready"
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case status
+        case name
+        case chunkCount = "chunk_count"
+    }
+
+    public init(id: String, status: String, name: String? = nil, chunkCount: Int? = nil) {
+        self.id = id
+        self.status = status
+        self.name = name
+        self.chunkCount = chunkCount
+    }
+}
+
+// MARK: - Ragie Retrieval
+
+/// A chunk returned by a Ragie retrieval query
+public struct RagieChunk: Codable {
+    public let text: String
+    public let score: Double
+    public let id: String
+    public let documentId: String
+    public let documentName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case score
+        case id
+        case documentId = "document_id"
+        case documentName = "document_name"
+    }
+
+    public init(
+        text: String,
+        score: Double,
+        id: String,
+        documentId: String,
+        documentName: String? = nil
+    ) {
+        self.text = text
+        self.score = score
+        self.id = id
+        self.documentId = documentId
+        self.documentName = documentName
+    }
+}
+
+/// Result of a Ragie retrieval query
+public struct RagieRetrievalResult: Codable {
+    public let query: String
+    public let chunks: [RagieChunk]
+
+    public var combinedText: String {
+        chunks.map(\.text).joined(separator: "\n\n")
+    }
+
+    public init(query: String, chunks: [RagieChunk]) {
+        self.query = query
+        self.chunks = chunks
+    }
+}
+
+// MARK: - Ragie Errors
+
+public enum RagieServiceError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case invalidResponseFormat
+    case apiError(statusCode: Int, message: String)
+    case networkError(Error)
+    case documentNotReady(status: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid Ragie API URL"
+        case .invalidResponse:
+            return "Invalid response from Ragie API"
+        case .invalidResponseFormat:
+            return "Could not parse Ragie API response"
+        case .apiError(let statusCode, let message):
+            return "Ragie API error (status \(statusCode)): \(message)"
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .documentNotReady(let status):
+            return "Document is not ready for retrieval (status: \(status))"
+        }
+    }
+}

--- a/Sources/WritersApp/Services/RagieService.swift
+++ b/Sources/WritersApp/Services/RagieService.swift
@@ -1,0 +1,270 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Service for document ingestion and retrieval using the Ragie API.
+///
+/// Ragie is a fully-managed RAG-as-a-Service that handles document chunking,
+/// embedding, and semantic retrieval. Use this service to:
+/// - Ingest writer documents into Ragie for semantic search
+/// - Retrieve relevant context chunks for AI-assisted writing
+///
+/// API base: https://api.ragie.ai
+/// Auth: `Authorization: Bearer <apiKey>`
+public class RagieService {
+    private let configuration: RagieConfiguration
+    private let baseURL = "https://api.ragie.ai"
+
+    public init(configuration: RagieConfiguration) {
+        self.configuration = configuration
+    }
+
+    // MARK: - Document Ingestion
+
+    /// Ingest raw text content into Ragie as a named document.
+    ///
+    /// The document will be chunked and embedded asynchronously. Poll
+    /// `getDocument(id:)` until `isReady` is true before querying.
+    ///
+    /// - Parameters:
+    ///   - text: The raw text content to ingest.
+    ///   - name: An optional display name for the document.
+    ///   - metadata: Optional key-value metadata for filtering retrievals.
+    /// - Returns: A `RagieDocument` with the new document's id and initial status.
+    public func ingestRawText(
+        _ text: String,
+        name: String? = nil,
+        metadata: [String: String] = [:]
+    ) async throws -> RagieDocument {
+        guard let url = URL(string: "\(baseURL)/documents/raw") else {
+            throw RagieServiceError.invalidURL
+        }
+
+        var body: [String: Any] = ["data": text]
+        if let name = name {
+            body["name"] = name
+        }
+        if !metadata.isEmpty {
+            body["metadata"] = metadata
+        }
+
+        let request = try buildRequest(url: url, method: "POST", body: body)
+        let data = try await performRequest(request)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = json["id"] as? String,
+              let status = json["status"] as? String else {
+            throw RagieServiceError.invalidResponseFormat
+        }
+
+        return RagieDocument(
+            id: id,
+            status: status,
+            name: json["name"] as? String,
+            chunkCount: json["chunk_count"] as? Int
+        )
+    }
+
+    /// Ingest a document from a URL into Ragie.
+    ///
+    /// - Parameters:
+    ///   - documentURL: The URL of the document to ingest.
+    ///   - name: An optional display name for the document.
+    ///   - metadata: Optional key-value metadata for filtering retrievals.
+    /// - Returns: A `RagieDocument` with the new document's id and initial status.
+    public func ingestURL(
+        _ documentURL: String,
+        name: String? = nil,
+        metadata: [String: String] = [:]
+    ) async throws -> RagieDocument {
+        guard let url = URL(string: "\(baseURL)/documents/url") else {
+            throw RagieServiceError.invalidURL
+        }
+
+        var body: [String: Any] = ["url": documentURL]
+        if let name = name {
+            body["name"] = name
+        }
+        if !metadata.isEmpty {
+            body["metadata"] = metadata
+        }
+
+        let request = try buildRequest(url: url, method: "POST", body: body)
+        let data = try await performRequest(request)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = json["id"] as? String,
+              let status = json["status"] as? String else {
+            throw RagieServiceError.invalidResponseFormat
+        }
+
+        return RagieDocument(
+            id: id,
+            status: status,
+            name: json["name"] as? String,
+            chunkCount: json["chunk_count"] as? Int
+        )
+    }
+
+    // MARK: - Document Status
+
+    /// Fetch the current status of a Ragie document.
+    ///
+    /// - Parameter id: The document id returned by `ingestRawText` or `ingestURL`.
+    /// - Returns: A `RagieDocument` with the current status. `isReady` is true when
+    ///            the document has been fully processed and is available for retrieval.
+    public func getDocument(id: String) async throws -> RagieDocument {
+        guard let url = URL(string: "\(baseURL)/documents/\(id)") else {
+            throw RagieServiceError.invalidURL
+        }
+
+        let request = try buildRequest(url: url, method: "GET", body: nil)
+        let data = try await performRequest(request)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let docId = json["id"] as? String,
+              let status = json["status"] as? String else {
+            throw RagieServiceError.invalidResponseFormat
+        }
+
+        return RagieDocument(
+            id: docId,
+            status: status,
+            name: json["name"] as? String,
+            chunkCount: json["chunk_count"] as? Int
+        )
+    }
+
+    // MARK: - Retrieval
+
+    /// Retrieve semantically relevant chunks from Ragie for a given query.
+    ///
+    /// - Parameters:
+    ///   - query: The natural-language query to search for.
+    ///   - topK: Override the number of chunks to return (defaults to `configuration.topK`).
+    ///   - rerank: Override reranking behavior (defaults to `configuration.rerank`).
+    ///   - filter: Optional metadata filter expression to restrict which documents are searched.
+    /// - Returns: A `RagieRetrievalResult` containing the matching chunks.
+    public func retrieve(
+        query: String,
+        topK: Int? = nil,
+        rerank: Bool? = nil,
+        filter: [String: Any]? = nil
+    ) async throws -> RagieRetrievalResult {
+        guard let url = URL(string: "\(baseURL)/retrievals") else {
+            throw RagieServiceError.invalidURL
+        }
+
+        var body: [String: Any] = [
+            "query": query,
+            "top_k": topK ?? configuration.topK,
+            "rerank": rerank ?? configuration.rerank
+        ]
+        if let filter = filter {
+            body["filter"] = filter
+        }
+
+        let request = try buildRequest(url: url, method: "POST", body: body)
+        let data = try await performRequest(request)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let scoredChunks = json["scored_chunks"] as? [[String: Any]] else {
+            throw RagieServiceError.invalidResponseFormat
+        }
+
+        let chunks = scoredChunks.compactMap { chunk -> RagieChunk? in
+            guard let text = chunk["text"] as? String,
+                  let chunkId = chunk["id"] as? String,
+                  let documentId = chunk["document_id"] as? String else {
+                return nil
+            }
+            // The Ragie API may return score as a JSON integer (0, 1) or float
+            let score: Double
+            if let d = chunk["score"] as? Double {
+                score = d
+            } else if let i = chunk["score"] as? Int {
+                score = Double(i)
+            } else {
+                return nil
+            }
+            return RagieChunk(
+                text: text,
+                score: score,
+                id: chunkId,
+                documentId: documentId,
+                documentName: chunk["document_name"] as? String
+            )
+        }
+
+        return RagieRetrievalResult(query: query, chunks: chunks)
+    }
+
+    // MARK: - Document Listing
+
+    /// List all documents stored in Ragie.
+    ///
+    /// - Returns: An array of `RagieDocument` representing all ingested documents.
+    public func listDocuments() async throws -> [RagieDocument] {
+        guard let url = URL(string: "\(baseURL)/documents") else {
+            throw RagieServiceError.invalidURL
+        }
+
+        let request = try buildRequest(url: url, method: "GET", body: nil)
+        let data = try await performRequest(request)
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let results = json["results"] as? [[String: Any]] else {
+            throw RagieServiceError.invalidResponseFormat
+        }
+
+        return results.compactMap { doc -> RagieDocument? in
+            guard let id = doc["id"] as? String,
+                  let status = doc["status"] as? String else {
+                return nil
+            }
+            return RagieDocument(
+                id: id,
+                status: status,
+                name: doc["name"] as? String,
+                chunkCount: doc["chunk_count"] as? Int
+            )
+        }
+    }
+
+    // MARK: - HTTP Helpers
+
+    private func buildRequest(url: URL, method: String, body: [String: Any]?) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+
+        if let body = body {
+            request.setValue("application/json", forHTTPHeaderField: "content-type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        return request
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> Data {
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw RagieServiceError.networkError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw RagieServiceError.invalidResponse
+        }
+
+        guard httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw RagieServiceError.apiError(statusCode: httpResponse.statusCode, message: message)
+        }
+
+        return data
+    }
+}

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -14,6 +14,7 @@ public class WritersApp {
     public private(set) var guiService: GuiNewService?
     public private(set) var aiService: AIService?
     public private(set) var chatbotService: ChatbotService?
+    public private(set) var ragieService: RagieService?
     public private(set) var currentUserId: UUID?
     private var currentSessionId: UUID?
     private var memoryPlugin: ClaudeMemoryPlugin?
@@ -81,6 +82,76 @@ public class WritersApp {
     /// Check if AI is available
     public var isAIEnabled: Bool {
         return aiService != nil
+    }
+
+    // MARK: - Ragie Integration
+
+    /// Enable Ragie document retrieval by providing configuration.
+    public func enableRagie(configuration: RagieConfiguration) {
+        self.ragieService = RagieService(configuration: configuration)
+    }
+
+    /// Disable Ragie document retrieval.
+    public func disableRagie() {
+        self.ragieService = nil
+    }
+
+    /// Whether the Ragie service is configured and available.
+    public var isRagieEnabled: Bool {
+        return ragieService != nil
+    }
+
+    /// Ingest a local document into Ragie for semantic retrieval.
+    ///
+    /// The document's content is sent to Ragie as raw text. The returned
+    /// `RagieDocument` includes the Ragie document id and initial processing status.
+    /// Poll `getRagieDocumentStatus(ragieId:)` until `isReady` is true before querying.
+    ///
+    /// - Parameter documentId: The id of the local `Document` to ingest.
+    /// - Returns: A `RagieDocument` describing the newly created Ragie document.
+    public func ingestDocumentToRagie(documentId: UUID) async throws -> RagieDocument {
+        guard let ragie = ragieService else { throw RagieError.ragieNotEnabled }
+        guard let document = documentManager.getDocument(id: documentId) else {
+            throw RagieError.documentNotFound
+        }
+        return try await ragie.ingestRawText(
+            document.content,
+            name: document.title,
+            metadata: ["document_id": documentId.uuidString, "category": document.category.rawValue]
+        )
+    }
+
+    /// Fetch the processing status of a Ragie document.
+    ///
+    /// - Parameter ragieId: The Ragie document id (from `ingestDocumentToRagie`).
+    /// - Returns: A `RagieDocument` with the current status (`isReady` when processable).
+    public func getRagieDocumentStatus(ragieId: String) async throws -> RagieDocument {
+        guard let ragie = ragieService else { throw RagieError.ragieNotEnabled }
+        return try await ragie.getDocument(id: ragieId)
+    }
+
+    /// Retrieve semantically relevant chunks from Ragie for a natural-language query.
+    ///
+    /// - Parameters:
+    ///   - query: The search query.
+    ///   - topK: Number of chunks to return (overrides configuration default).
+    ///   - rerank: Whether to apply reranking (overrides configuration default).
+    /// - Returns: A `RagieRetrievalResult` with matching text chunks and scores.
+    public func retrieveFromRagie(
+        query: String,
+        topK: Int? = nil,
+        rerank: Bool? = nil
+    ) async throws -> RagieRetrievalResult {
+        guard let ragie = ragieService else { throw RagieError.ragieNotEnabled }
+        return try await ragie.retrieve(query: query, topK: topK, rerank: rerank)
+    }
+
+    /// List all documents currently stored in Ragie.
+    ///
+    /// - Returns: An array of `RagieDocument` entries.
+    public func listRagieDocuments() async throws -> [RagieDocument] {
+        guard let ragie = ragieService else { throw RagieError.ragieNotEnabled }
+        return try await ragie.listDocuments()
     }
 
     /// Enable adult content mode for Jules (no content restrictions, curse words allowed)
@@ -930,6 +1001,20 @@ public enum AIError: LocalizedError {
         switch self {
         case .aiNotEnabled:
             return "AI features are not enabled. Please configure AI with enableAI(configuration:) first."
+        case .documentNotFound:
+            return "The specified document was not found."
+        }
+    }
+}
+
+public enum RagieError: LocalizedError, Equatable {
+    case ragieNotEnabled
+    case documentNotFound
+
+    public var errorDescription: String? {
+        switch self {
+        case .ragieNotEnabled:
+            return "Ragie is not enabled. Please configure it with enableRagie(configuration:) first."
         case .documentNotFound:
             return "The specified document was not found."
         }

--- a/Sources/WritersAppCLI/main.swift
+++ b/Sources/WritersAppCLI/main.swift
@@ -270,6 +270,15 @@ struct WritersAppCLI {
             print("ⓘ gui.new visual export available (set GUI_NEW_API_KEY for Pro)")
         }
 
+        // Initialize Ragie if API key is present
+        if let ragieKey = ProcessInfo.processInfo.environment["RAGIE_API_KEY"], !ragieKey.isEmpty {
+            let ragieConfig = RagieConfiguration(apiKey: ragieKey)
+            app.enableRagie(configuration: ragieConfig)
+            print("✓ Ragie document retrieval enabled")
+        } else {
+            print("ⓘ Ragie disabled (set RAGIE_API_KEY to enable document retrieval)")
+        }
+
         // Initialize Claude Memory plugin
         do {
             try await app.enableMemoryPlugin()
@@ -367,6 +376,14 @@ struct WritersAppCLI {
             print("90. Export Statistics Dashboard to gui.new")
             print("91. Export Document to gui.new")
             print("92. Export Kanban Board to gui.new")
+
+            if app.isRagieEnabled {
+                print("\nRagie Document Retrieval:")
+                print("95. Ingest Document into Ragie")
+                print("96. Retrieve Context from Ragie")
+                print("97. List Ragie Documents")
+                print("98. Check Ragie Document Status")
+            }
 
             print("\n0. Exit")
             print()
@@ -494,6 +511,14 @@ struct WritersAppCLI {
                 await exportDocumentToGuiInteractive(app: app)
             case 92:
                 await exportKanbanBoardToGuiInteractive(app: app)
+            case 95:
+                await ingestDocumentToRagie(app: app)
+            case 96:
+                await retrieveContextFromRagie(app: app)
+            case 97:
+                await listRagieDocuments(app: app)
+            case 98:
+                await checkRagieDocumentStatus(app: app)
             case 0:
                 await app.shutdownPlugins()
                 running = false
@@ -3540,6 +3565,130 @@ func exportKanbanBoardToGuiInteractive(app: WritersApp) async {
         print("  Expires: \(canvas.expiresAt)")
     } catch {
         print("✗ Export failed: \(error.localizedDescription)")
+    }
+}
+
+// MARK: - Ragie Document Retrieval
+
+func ingestDocumentToRagie(app: WritersApp) async {
+    guard app.isRagieEnabled else {
+        print("Ragie is not enabled. Set RAGIE_API_KEY to use this feature.")
+        return
+    }
+
+    let documents = app.documentManager.getAllDocuments()
+    guard !documents.isEmpty else {
+        print("No documents available to ingest.")
+        return
+    }
+
+    print("\n=== Ingest Document into Ragie ===\n")
+    for (index, doc) in documents.enumerated() {
+        print("\(index + 1). \(doc.title) (\(doc.wordCount) words)")
+    }
+    print("\nEnter document number: ", terminator: "")
+
+    guard let input = readLine(), let idx = Int(input), idx > 0, idx <= documents.count else {
+        print("Invalid selection.")
+        return
+    }
+
+    let document = documents[idx - 1]
+    print("Ingesting '\(document.title)' into Ragie...")
+
+    do {
+        let ragieDoc = try await app.ingestDocumentToRagie(documentId: document.id)
+        print("✓ Document ingested successfully!")
+        print("  Ragie ID: \(ragieDoc.id)")
+        print("  Status:   \(ragieDoc.status)")
+        if !ragieDoc.isReady {
+            print("  ⓘ Document is processing. Use option 98 to check when it's ready.")
+        }
+    } catch {
+        print("✗ Ingestion failed: \(error.localizedDescription)")
+    }
+}
+
+func retrieveContextFromRagie(app: WritersApp) async {
+    guard app.isRagieEnabled else {
+        print("Ragie is not enabled. Set RAGIE_API_KEY to use this feature.")
+        return
+    }
+
+    print("\n=== Retrieve Context from Ragie ===\n")
+    print("Enter your query: ", terminator: "")
+    guard let query = readLine(), !query.isEmpty else {
+        print("Query cannot be empty.")
+        return
+    }
+
+    print("Searching Ragie for: \"\(query)\"...")
+
+    do {
+        let result = try await app.retrieveFromRagie(query: query)
+        if result.chunks.isEmpty {
+            print("No relevant chunks found for this query.")
+        } else {
+            print("\nFound \(result.chunks.count) relevant chunk(s):\n")
+            for (i, chunk) in result.chunks.enumerated() {
+                let docName = chunk.documentName ?? chunk.documentId
+                print("[\(i + 1)] Score: \(String(format: "%.3f", chunk.score))  Source: \(docName)")
+                print(chunk.text)
+                print()
+            }
+        }
+    } catch {
+        print("✗ Retrieval failed: \(error.localizedDescription)")
+    }
+}
+
+func listRagieDocuments(app: WritersApp) async {
+    guard app.isRagieEnabled else {
+        print("Ragie is not enabled. Set RAGIE_API_KEY to use this feature.")
+        return
+    }
+
+    print("\n=== Ragie Documents ===\n")
+
+    do {
+        let documents = try await app.listRagieDocuments()
+        if documents.isEmpty {
+            print("No documents ingested into Ragie yet.")
+        } else {
+            for doc in documents {
+                let readyMark = doc.isReady ? "✓" : "⏳"
+                let chunkInfo = doc.chunkCount.map { " (\($0) chunks)" } ?? ""
+                let name = doc.name ?? "(unnamed)"
+                print("\(readyMark) \(name)\(chunkInfo)")
+                print("   ID: \(doc.id)  Status: \(doc.status)")
+            }
+        }
+    } catch {
+        print("✗ Failed to list Ragie documents: \(error.localizedDescription)")
+    }
+}
+
+func checkRagieDocumentStatus(app: WritersApp) async {
+    guard app.isRagieEnabled else {
+        print("Ragie is not enabled. Set RAGIE_API_KEY to use this feature.")
+        return
+    }
+
+    print("\n=== Check Ragie Document Status ===\n")
+    print("Enter Ragie document ID: ", terminator: "")
+    guard let ragieId = readLine(), !ragieId.isEmpty else {
+        print("Document ID cannot be empty.")
+        return
+    }
+
+    do {
+        let doc = try await app.getRagieDocumentStatus(ragieId: ragieId)
+        let readyMark = doc.isReady ? "✓ Ready" : "⏳ \(doc.status.capitalized)"
+        print("Status: \(readyMark)")
+        if let name = doc.name { print("Name:   \(name)") }
+        if let chunks = doc.chunkCount { print("Chunks: \(chunks)") }
+    } catch {
+        print("✗ Status check failed: \(error.localizedDescription)")
     }
 }
 

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -1152,4 +1152,132 @@ final class WritersAppTests: XCTestCase {
         app.disableGui()
         XCTAssertFalse(app.isGuiEnabled, "gui.new should be disabled after disableGui()")
     }
+
+    // MARK: - Ragie Integration Tests
+
+    func testRagieConfigurationDefaults() {
+        let config = RagieConfiguration(apiKey: "test-key")
+        XCTAssertEqual(config.apiKey, "test-key")
+        XCTAssertEqual(config.topK, 8)
+        XCTAssertFalse(config.rerank)
+    }
+
+    func testRagieConfigurationCustomValues() {
+        let config = RagieConfiguration(apiKey: "sk-ragie-123", topK: 5, rerank: true)
+        XCTAssertEqual(config.apiKey, "sk-ragie-123")
+        XCTAssertEqual(config.topK, 5)
+        XCTAssertTrue(config.rerank)
+    }
+
+    func testRagieDocumentIsReady() {
+        let readyDoc = RagieDocument(id: "doc-1", status: "ready", name: "Test Doc", chunkCount: 10)
+        XCTAssertTrue(readyDoc.isReady)
+
+        let processingDoc = RagieDocument(id: "doc-2", status: "processing")
+        XCTAssertFalse(processingDoc.isReady)
+    }
+
+    func testRagieChunkDecoding() throws {
+        let json = """
+        {"text":"Hello world","score":0.95,"id":"chunk-1","document_id":"doc-1","document_name":"MyDoc"}
+        """.data(using: .utf8)!
+        let chunk = try JSONDecoder().decode(RagieChunk.self, from: json)
+        XCTAssertEqual(chunk.text, "Hello world")
+        XCTAssertEqual(chunk.score, 0.95, accuracy: 0.001)
+        XCTAssertEqual(chunk.id, "chunk-1")
+        XCTAssertEqual(chunk.documentId, "doc-1")
+        XCTAssertEqual(chunk.documentName, "MyDoc")
+    }
+
+    func testRagieRetrievalResultCombinedText() {
+        let chunks = [
+            RagieChunk(text: "First chunk", score: 0.9, id: "c1", documentId: "d1"),
+            RagieChunk(text: "Second chunk", score: 0.8, id: "c2", documentId: "d1")
+        ]
+        let result = RagieRetrievalResult(query: "test query", chunks: chunks)
+        XCTAssertEqual(result.combinedText, "First chunk\n\nSecond chunk")
+    }
+
+    func testRagieRetrievalResultEmptyChunks() {
+        let result = RagieRetrievalResult(query: "no results", chunks: [])
+        XCTAssertTrue(result.chunks.isEmpty)
+        XCTAssertEqual(result.combinedText, "")
+    }
+
+    func testWritersAppRagieEnableDisable() {
+        XCTAssertFalse(app.isRagieEnabled, "Ragie should be disabled by default")
+        let config = RagieConfiguration(apiKey: "test-key")
+        app.enableRagie(configuration: config)
+        XCTAssertTrue(app.isRagieEnabled, "Ragie should be enabled after enableRagie()")
+        app.disableRagie()
+        XCTAssertFalse(app.isRagieEnabled, "Ragie should be disabled after disableRagie()")
+    }
+
+    func testIngestDocumentToRagieRequiresRagieEnabled() async {
+        // Ragie not enabled — should throw ragieNotEnabled regardless of document existence
+        let doc = app.createBlankDocument(title: "Test", category: .article)
+        do {
+            _ = try await app.ingestDocumentToRagie(documentId: doc.id)
+            XCTFail("Should throw when Ragie is not enabled")
+        } catch let error as RagieError {
+            XCTAssertEqual(error, .ragieNotEnabled)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testIngestDocumentToRagieThrowsDocumentNotFoundWhenDocumentMissing() async {
+        let config = RagieConfiguration(apiKey: "test-key")
+        app.enableRagie(configuration: config)
+        defer { app.disableRagie() }
+
+        do {
+            _ = try await app.ingestDocumentToRagie(documentId: UUID())
+            XCTFail("Should throw documentNotFound for unknown document")
+        } catch let error as RagieError {
+            XCTAssertEqual(error, .documentNotFound)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRetrieveFromRagieRequiresRagieEnabled() async {
+        do {
+            _ = try await app.retrieveFromRagie(query: "test")
+            XCTFail("Should throw when Ragie is not enabled")
+        } catch let error as RagieError {
+            XCTAssertEqual(error, .ragieNotEnabled)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testListRagieDocumentsRequiresRagieEnabled() async {
+        do {
+            _ = try await app.listRagieDocuments()
+            XCTFail("Should throw when Ragie is not enabled")
+        } catch let error as RagieError {
+            XCTAssertEqual(error, .ragieNotEnabled)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRagieServiceErrorDescriptions() {
+        XCTAssertNotNil(RagieServiceError.invalidURL.errorDescription)
+        XCTAssertNotNil(RagieServiceError.invalidResponse.errorDescription)
+        XCTAssertNotNil(RagieServiceError.invalidResponseFormat.errorDescription)
+        XCTAssertNotNil(RagieServiceError.apiError(statusCode: 401, message: "Unauthorized").errorDescription)
+        XCTAssertNotNil(RagieServiceError.documentNotReady(status: "processing").errorDescription)
+    }
+
+    func testRagieDocumentCodable() throws {
+        let doc = RagieDocument(id: "doc-123", status: "ready", name: "My Doc", chunkCount: 42)
+        let encoded = try JSONEncoder().encode(doc)
+        let decoded = try JSONDecoder().decode(RagieDocument.self, from: encoded)
+        XCTAssertEqual(decoded.id, doc.id)
+        XCTAssertEqual(decoded.status, doc.status)
+        XCTAssertEqual(decoded.name, doc.name)
+        XCTAssertEqual(decoded.chunkCount, doc.chunkCount)
+    }
 }


### PR DESCRIPTION
Integrates Ragie (RAG-as-a-Service) as a complementary retrieval layer
alongside the existing Claude AI features.

New files:
- Sources/WritersApp/Models/RagieModels.swift: RagieConfiguration,
  RagieDocument, RagieChunk, RagieRetrievalResult, RagieServiceError
- Sources/WritersApp/Services/RagieService.swift: HTTP client wrapping
  the Ragie REST API (api.ragie.ai) — ingestRawText, ingestURL,
  getDocument, retrieve, listDocuments

Changes to existing files:
- WritersApp.swift: ragieService property, enableRagie/disableRagie,
  ingestDocumentToRagie, getRagieDocumentStatus, retrieveFromRagie,
  listRagieDocuments, RagieError enum
- main.swift: RAGIE_API_KEY env-var detection, menu options 95-98
  (ingest, retrieve, list, status check), handler functions
- WritersAppTests.swift: 11 new tests covering RagieConfiguration,
  RagieDocument.isReady, JSON decoding, combinedText, enable/disable,
  and error guard paths

https://claude.ai/code/session_01TPDm67DvsTfjV7Rq7uYzRn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Ragie API integration enabling semantic document search and retrieval
  * Document ingestion: add documents with optional metadata
  * Document management: list ingested documents and check status
  * Context retrieval with configurable search parameters (result count, reranking)
  * CLI extended with Ragie menu options

* **Tests**
  * Added comprehensive test coverage for Ragie functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->