### PR TITLE
Make Swift installation in session-start hook resilient to network failures

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -19,22 +19,29 @@ if ! command -v swift &>/dev/null; then
 
   ARCH="$(uname -m)"
   cd /tmp
-  curl -fsSLO "https://download.swift.org/swiftly/linux/swiftly-${ARCH}.tar.gz"
-  tar zxf "swiftly-${ARCH}.tar.gz"
-  ./swiftly init --quiet-shell-followup -y
-  . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
-  hash -r
-  rm -f "swiftly-${ARCH}.tar.gz" swiftly
+  if curl -sSLO "https://download.swift.org/swiftly/linux/swiftly-${ARCH}.tar.gz" 2>/dev/null && [ -f "swiftly-${ARCH}.tar.gz" ]; then
+    tar zxf "swiftly-${ARCH}.tar.gz"
+    ./swiftly init --quiet-shell-followup -y
+    . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
+    hash -r
+    rm -f "swiftly-${ARCH}.tar.gz" swiftly
 
-  # Persist PATH for the session
-  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-    echo ". \"${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh\"" >> "$CLAUDE_ENV_FILE"
+    # Persist PATH for the session
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      echo ". \"${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh\"" >> "$CLAUDE_ENV_FILE"
+    fi
+  else
+    echo "Warning: Could not download swiftly from swift.org. Swift must be installed manually." >&2
   fi
 fi
 
 # Build the project to resolve dependencies and cache build artifacts
-cd "$CLAUDE_PROJECT_DIR"
-swift build 2>&1
+if command -v swift &>/dev/null; then
+  cd "$CLAUDE_PROJECT_DIR"
+  swift build 2>&1
+else
+  echo "Warning: swift not found — skipping build step." >&2
+fi
 
 # Install Firecrawl CLI for web scraping, searching, and browsing
 if ! command -v firecrawl &>/dev/null; then


### PR DESCRIPTION
Replace hard-failing curl with a conditional check so the hook continues
gracefully when swift.org is unreachable (e.g. proxy-restricted envs).
Build step is skipped with a warning instead of aborting the whole hook.

https://claude.ai/code/session_01JqkyL52fdgGryHyPcYHdu7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Installation process is now more resilient to network issues and missing dependencies. Failed downloads and unavailable components trigger informative warnings and gracefully skip setup steps rather than causing complete failures.
  * Enhanced error handling and user feedback throughout initialization when critical components are not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->