### PR TITLE
Add Mocker to Containers/Orchestration CLI Tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,16 @@ When running as an MCP server, the following tools are available:
 - [CLOTHER.md](CLOTHER.md) - Using 100+ LLM providers with Clother
 - [CLOTHER_SETUP.md](CLOTHER_SETUP.md) - Contributor guide for Clother development
 
+## Containers/Orchestration
+
+### CLI Tools
+
+<p>
+&nbsp;&nbsp; <a href="https://github.com/google/gvisor"><b>gvisor</b></a> - container runtime sandbox.<br>
+&nbsp;&nbsp; <a href="https://github.com/bcicen/ctop"><b>ctop</b></a> - top-like interface for container metrics.<br>
+&nbsp;&nbsp; <a href="https://github.com/us/mocker"><b>Mocker</b></a> - docker-compatible container CLI for macOS, built on Apple's Containerization framework.<br>
+</p>
+
 ## License
 
 MIT License - See LICENSE file for details


### PR DESCRIPTION
Adds a new Containers/Orchestration section with a CLI Tools list
including gvisor, ctop, and Mocker. The Mocker entry documents a
docker-compatible container CLI for macOS built on Apple's
Containerization framework, with description in lowercase per
style consistency with surrounding entries.

https://claude.ai/code/session_01Q1UFmiTZYBChRuDAdggLRN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section documenting container and orchestration CLI tools with links to their respective GitHub repositories for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->