### PR TITLE
Add Cowork Mode: Gmail + prospect database + browser in one session

### DIFF
--- a/Sources/WritersApp/Models/CoworkModels.swift
+++ b/Sources/WritersApp/Models/CoworkModels.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+// MARK: - Prospect
+
+/// A writing prospect — publisher, agent, client, or collaborator tracked by the solo founder.
+public struct Prospect: Codable, Identifiable {
+    public var id: UUID
+    public var name: String
+    public var email: String
+    public var company: String?
+    public var role: String?
+    public var status: ProspectStatus
+    public var notes: String
+    public var tags: [String]
+    public var lastContactedAt: Date?
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        email: String,
+        company: String? = nil,
+        role: String? = nil,
+        status: ProspectStatus = .new,
+        notes: String = "",
+        tags: [String] = [],
+        lastContactedAt: Date? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.company = company
+        self.role = role
+        self.status = status
+        self.notes = notes
+        self.tags = tags
+        self.lastContactedAt = lastContactedAt
+        self.createdAt = createdAt
+    }
+}
+
+public enum ProspectStatus: String, Codable, CaseIterable {
+    case new
+    case contacted
+    case replied
+    case meeting
+    case declined
+    case converted
+
+    public var displayName: String {
+        switch self {
+        case .new:       return "New"
+        case .contacted: return "Contacted"
+        case .replied:   return "Replied"
+        case .meeting:   return "Meeting Scheduled"
+        case .declined:  return "Declined"
+        case .converted: return "Converted"
+        }
+    }
+}
+
+// MARK: - Gmail
+
+/// A Gmail message fetched via the Gmail REST API.
+public struct GmailMessage: Codable, Identifiable {
+    public var id: String
+    public var threadId: String
+    public var subject: String
+    public var from: String
+    public var to: [String]
+    public var snippet: String
+    public var body: String
+    public var date: Date
+    public var isRead: Bool
+    public var labels: [String]
+
+    public init(
+        id: String,
+        threadId: String,
+        subject: String,
+        from: String,
+        to: [String],
+        snippet: String,
+        body: String,
+        date: Date,
+        isRead: Bool = false,
+        labels: [String] = []
+    ) {
+        self.id = id
+        self.threadId = threadId
+        self.subject = subject
+        self.from = from
+        self.to = to
+        self.snippet = snippet
+        self.body = body
+        self.date = date
+        self.isRead = isRead
+        self.labels = labels
+    }
+}
+
+/// A composed email ready to send via Gmail.
+public struct GmailDraft: Codable, Identifiable {
+    public var id: UUID
+    public var to: String
+    public var subject: String
+    public var body: String
+    public var inReplyTo: String?
+
+    public init(
+        id: UUID = UUID(),
+        to: String,
+        subject: String,
+        body: String,
+        inReplyTo: String? = nil
+    ) {
+        self.id = id
+        self.to = to
+        self.subject = subject
+        self.body = body
+        self.inReplyTo = inReplyTo
+    }
+}
+
+// MARK: - Browser
+
+/// A web page fetched and stripped to plain text for writing research.
+public struct BrowsedPage: Codable, Identifiable {
+    public var id: UUID
+    public var url: String
+    public var title: String
+    public var textContent: String
+    public var fetchedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        url: String,
+        title: String,
+        textContent: String,
+        fetchedAt: Date = Date()
+    ) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.textContent = textContent
+        self.fetchedAt = fetchedAt
+    }
+}
+
+// MARK: - Cowork Session
+
+/// Tracks a single cowork session — a focused block where the founder works
+/// across Gmail, prospects, and browser research.
+public struct CoworkSession: Codable, Identifiable {
+    public var id: UUID
+    public var startedAt: Date
+    public var endedAt: Date?
+    public var emailsSent: Int
+    public var prospectsAdded: Int
+    public var prospectsContacted: Int
+    public var pagesResearched: Int
+
+    public init(
+        id: UUID = UUID(),
+        startedAt: Date = Date(),
+        endedAt: Date? = nil,
+        emailsSent: Int = 0,
+        prospectsAdded: Int = 0,
+        prospectsContacted: Int = 0,
+        pagesResearched: Int = 0
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.emailsSent = emailsSent
+        self.prospectsAdded = prospectsAdded
+        self.prospectsContacted = prospectsContacted
+        self.pagesResearched = pagesResearched
+    }
+
+    /// Duration in minutes if the session has ended.
+    public var durationMinutes: Double? {
+        guard let end = endedAt else { return nil }
+        return end.timeIntervalSince(startedAt) / 60.0
+    }
+}
+
+// MARK: - Errors
+
+public enum CoworkError: Error, LocalizedError {
+    case gmailNotEnabled
+    case invalidOAuthToken
+    case prospectNotFound(UUID)
+    case browserFetchFailed(String)
+    case networkError(String)
+    case invalidURL
+
+    public var errorDescription: String? {
+        switch self {
+        case .gmailNotEnabled:
+            return "Gmail is not enabled. Set GMAIL_OAUTH_TOKEN to activate."
+        case .invalidOAuthToken:
+            return "Gmail OAuth token is invalid or expired."
+        case .prospectNotFound:
+            return "Prospect not found."
+        case .browserFetchFailed(let reason):
+            return "Browser fetch failed: \(reason)"
+        case .networkError(let message):
+            return "Network error: \(message)"
+        case .invalidURL:
+            return "The URL is invalid."
+        }
+    }
+}

--- a/Sources/WritersApp/Services/CoworkService.swift
+++ b/Sources/WritersApp/Services/CoworkService.swift
@@ -1,0 +1,396 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - ProspectDatabase
+
+/// In-memory database for tracking writing prospects: publishers, agents, clients, collaborators.
+public class ProspectDatabase {
+    private var prospects: [UUID: Prospect] = [:]
+
+    public init() {}
+
+    // MARK: CRUD
+
+    public func addProspect(_ prospect: Prospect) {
+        prospects[prospect.id] = prospect
+    }
+
+    public func getProspect(id: UUID) -> Prospect? {
+        return prospects[id]
+    }
+
+    public func getAllProspects() -> [Prospect] {
+        return Array(prospects.values).sorted { $0.createdAt > $1.createdAt }
+    }
+
+    public func getProspects(withStatus status: ProspectStatus) -> [Prospect] {
+        return getAllProspects().filter { $0.status == status }
+    }
+
+    public func updateProspect(_ prospect: Prospect) {
+        prospects[prospect.id] = prospect
+    }
+
+    public func updateProspectStatus(id: UUID, status: ProspectStatus) throws {
+        guard var prospect = prospects[id] else {
+            throw CoworkError.prospectNotFound(id)
+        }
+        prospect.status = status
+        if status == .contacted || status == .replied || status == .meeting {
+            prospect.lastContactedAt = Date()
+        }
+        prospects[id] = prospect
+    }
+
+    public func deleteProspect(id: UUID) {
+        prospects.removeValue(forKey: id)
+    }
+
+    public func searchProspects(query: String) -> [Prospect] {
+        let q = query.lowercased()
+        return getAllProspects().filter {
+            $0.name.lowercased().contains(q) ||
+            $0.email.lowercased().contains(q) ||
+            ($0.company?.lowercased().contains(q) ?? false) ||
+            $0.notes.lowercased().contains(q) ||
+            $0.tags.contains { $0.lowercased().contains(q) }
+        }
+    }
+
+    // MARK: Statistics
+
+    public func getStats() -> [ProspectStatus: Int] {
+        var counts: [ProspectStatus: Int] = [:]
+        for status in ProspectStatus.allCases {
+            counts[status] = 0
+        }
+        for prospect in prospects.values {
+            counts[prospect.status, default: 0] += 1
+        }
+        return counts
+    }
+}
+
+// MARK: - GmailService
+
+/// Gmail API client. Authenticates via OAuth 2.0 bearer token supplied at init time.
+/// Token must come from the caller (e.g. read from an environment variable in the CLI layer).
+public class GmailService {
+    private let oauthToken: String
+    private let baseURL = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+    public init(oauthToken: String) {
+        self.oauthToken = oauthToken
+    }
+
+    // MARK: List messages
+
+    /// Fetch a list of messages from the inbox.
+    /// - Parameters:
+    ///   - maxResults: Maximum number of messages to fetch (default 20).
+    ///   - query: Optional Gmail search query (e.g. `"from:agent@example.com"`).
+    public func listMessages(maxResults: Int = 20, query: String? = nil) async throws -> [GmailMessage] {
+        var urlString = "\(baseURL)/messages?maxResults=\(maxResults)"
+        if let q = query, !q.isEmpty {
+            let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? q
+            urlString += "&q=\(encoded)"
+        }
+        guard let url = URL(string: urlString) else { throw CoworkError.invalidURL }
+
+        let listData = try await performRequest(url: url, method: "GET")
+        guard let json = try JSONSerialization.jsonObject(with: listData) as? [String: Any],
+              let messageList = json["messages"] as? [[String: Any]] else {
+            return []
+        }
+
+        var messages: [GmailMessage] = []
+        for item in messageList.prefix(maxResults) {
+            if let msgId = item["id"] as? String,
+               let msg = try? await getMessage(id: msgId) {
+                messages.append(msg)
+            }
+        }
+        return messages
+    }
+
+    // MARK: Get single message
+
+    /// Fetch the full content of a specific message.
+    public func getMessage(id: String) async throws -> GmailMessage {
+        guard let url = URL(string: "\(baseURL)/messages/\(id)?format=full") else {
+            throw CoworkError.invalidURL
+        }
+        let data = try await performRequest(url: url, method: "GET")
+        return try parseMessage(data: data)
+    }
+
+    // MARK: Send message
+
+    /// Send an email via Gmail.
+    /// - Parameter draft: The composed email to send.
+    /// - Returns: The sent message ID.
+    @discardableResult
+    public func sendMessage(draft: GmailDraft) async throws -> String {
+        let rawMessage = buildRFC2822(draft: draft)
+        var base64 = Data(rawMessage.utf8).base64EncodedString()
+        base64 = base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        var body: [String: Any] = ["raw": base64]
+        if let replyTo = draft.inReplyTo {
+            body["threadId"] = replyTo
+        }
+
+        guard let url = URL(string: "\(baseURL)/messages/send") else {
+            throw CoworkError.invalidURL
+        }
+        let responseData = try await performRequest(url: url, method: "POST", body: body)
+        guard let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let sentId = json["id"] as? String else {
+            throw CoworkError.networkError("Unexpected send response format")
+        }
+        return sentId
+    }
+
+    // MARK: Mark as read
+
+    /// Mark a message as read by removing the UNREAD label.
+    public func markAsRead(id: String) async throws {
+        guard let url = URL(string: "\(baseURL)/messages/\(id)/modify") else {
+            throw CoworkError.invalidURL
+        }
+        let body: [String: Any] = ["removeLabelIds": ["UNREAD"]]
+        _ = try await performRequest(url: url, method: "POST", body: body)
+    }
+
+    // MARK: - Private helpers
+
+    private func buildRFC2822(draft: GmailDraft) -> String {
+        var headers = [
+            "To: \(draft.to)",
+            "Subject: \(draft.subject)",
+            "Content-Type: text/plain; charset=UTF-8"
+        ]
+        if let replyTo = draft.inReplyTo {
+            headers.append("In-Reply-To: \(replyTo)")
+            headers.append("References: \(replyTo)")
+        }
+        return (headers + ["", draft.body]).joined(separator: "\r\n")
+    }
+
+    private func parseMessage(data: Data) throws -> GmailMessage {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CoworkError.networkError("Invalid message JSON")
+        }
+
+        let id = json["id"] as? String ?? ""
+        let threadId = json["threadId"] as? String ?? ""
+        let snippet = json["snippet"] as? String ?? ""
+        let internalDate = (json["internalDate"] as? String).flatMap { Double($0) }
+        let date = internalDate.map { Date(timeIntervalSince1970: $0 / 1000.0) } ?? Date()
+        let labelIds = json["labelIds"] as? [String] ?? []
+        let isRead = !labelIds.contains("UNREAD")
+
+        var subject = ""
+        var from = ""
+        var to: [String] = []
+        var body = ""
+
+        if let payload = json["payload"] as? [String: Any] {
+            if let headers = payload["headers"] as? [[String: Any]] {
+                for header in headers {
+                    let name = (header["name"] as? String ?? "").lowercased()
+                    let value = header["value"] as? String ?? ""
+                    switch name {
+                    case "subject": subject = value
+                    case "from":    from = value
+                    case "to":      to = value.components(separatedBy: ",")
+                                        .map { $0.trimmingCharacters(in: .whitespaces) }
+                    default: break
+                    }
+                }
+            }
+            body = extractBody(payload: payload)
+        }
+
+        return GmailMessage(
+            id: id,
+            threadId: threadId,
+            subject: subject,
+            from: from,
+            to: to,
+            snippet: snippet,
+            body: body,
+            date: date,
+            isRead: isRead,
+            labels: labelIds
+        )
+    }
+
+    private func extractBody(payload: [String: Any]) -> String {
+        if let bodySection = payload["body"] as? [String: Any],
+           let encoded = bodySection["data"] as? String,
+           let text = decodeBase64URL(encoded) {
+            return text
+        }
+        if let parts = payload["parts"] as? [[String: Any]] {
+            for part in parts {
+                let mimeType = part["mimeType"] as? String ?? ""
+                guard mimeType == "text/plain" else { continue }
+                if let bodySection = part["body"] as? [String: Any],
+                   let encoded = bodySection["data"] as? String,
+                   let text = decodeBase64URL(encoded) {
+                    return text
+                }
+            }
+        }
+        return ""
+    }
+
+    private func decodeBase64URL(_ encoded: String) -> String? {
+        var padded = encoded
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = padded.count % 4
+        if remainder > 0 {
+            padded += String(repeating: "=", count: 4 - remainder)
+        }
+        guard let data = Data(base64Encoded: padded) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func performRequest(
+        url: URL,
+        method: String,
+        body: [String: Any]? = nil
+    ) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(oauthToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let body = body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse {
+            if httpResponse.statusCode == 401 {
+                throw CoworkError.invalidOAuthToken
+            }
+            if httpResponse.statusCode >= 400 {
+                let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+                throw CoworkError.networkError("HTTP \(httpResponse.statusCode): \(message)")
+            }
+        }
+        return data
+    }
+}
+
+// MARK: - BrowserService
+
+/// Fetches web pages and extracts readable plain-text content for research.
+public class BrowserService {
+    private(set) public var history: [BrowsedPage] = []
+
+    public init() {}
+
+    // MARK: Fetch
+
+    /// Fetch a URL and return its text content.
+    /// - Parameter urlString: The URL to fetch (must begin with http:// or https://).
+    public func fetch(urlString: String) async throws -> BrowsedPage {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme,
+              scheme == "http" || scheme == "https" else {
+            throw CoworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(
+            "Mozilla/5.0 (compatible; WritersApp/1.0)",
+            forHTTPHeaderField: "User-Agent"
+        )
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
+            throw CoworkError.browserFetchFailed("HTTP \(httpResponse.statusCode)")
+        }
+
+        let rawHTML = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .isoLatin1)
+            ?? ""
+        let title = extractHTMLTitle(from: rawHTML)
+        let text = stripHTML(rawHTML)
+
+        let page = BrowsedPage(url: urlString, title: title, textContent: text)
+        history.append(page)
+        return page
+    }
+
+    /// Clear the in-session browsing history.
+    public func clearHistory() {
+        history.removeAll()
+    }
+
+    // MARK: - HTML parsing helpers
+
+    private func extractHTMLTitle(from html: String) -> String {
+        guard let titleStart = html.range(of: "<title", options: .caseInsensitive),
+              let tagEnd = html.range(of: ">", range: titleStart.upperBound..<html.endIndex),
+              let titleEnd = html.range(
+                  of: "</title>",
+                  options: .caseInsensitive,
+                  range: tagEnd.upperBound..<html.endIndex
+              ) else {
+            return "Untitled"
+        }
+        return String(html[tagEnd.upperBound..<titleEnd.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func stripHTML(_ html: String) -> String {
+        var text = html
+
+        // Remove script, style, and head blocks entirely
+        for tag in ["script", "style", "head"] {
+            while let start = text.range(of: "<\(tag)", options: .caseInsensitive),
+                  let end = text.range(
+                      of: "</\(tag)>",
+                      options: .caseInsensitive,
+                      range: start.lowerBound..<text.endIndex
+                  ) {
+                text.removeSubrange(start.lowerBound...end.upperBound)
+            }
+        }
+
+        // Replace block-level tags with newlines
+        for tag in ["p", "div", "br", "h1", "h2", "h3", "h4", "h5", "h6", "li", "tr", "td", "th"] {
+            text = text.replacingOccurrences(
+                of: "<\(tag)[^>]*>", with: "\n", options: .regularExpression)
+            text = text.replacingOccurrences(of: "</\(tag)>", with: "\n")
+        }
+
+        // Strip all remaining tags
+        text = text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+
+        // Decode common HTML entities
+        let entities: [(String, String)] = [
+            ("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"),
+            ("&quot;", "\""), ("&#39;", "'"), ("&nbsp;", " "),
+            ("&mdash;", "—"), ("&ndash;", "–"), ("&hellip;", "…")
+        ]
+        for (entity, replacement) in entities {
+            text = text.replacingOccurrences(of: entity, with: replacement)
+        }
+
+        // Collapse whitespace — keep only non-empty lines
+        let lines = text.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -19,6 +19,12 @@ public class WritersApp {
     private var currentSessionId: UUID?
     private var memoryPlugin: ClaudeMemoryPlugin?
 
+    // MARK: - Cowork Mode
+    public let prospectDatabase: ProspectDatabase
+    public let browserService: BrowserService
+    public private(set) var gmailService: GmailService?
+    public private(set) var activeCoworkSession: CoworkSession?
+
     public convenience init() {
         self.init(databaseManager: DatabaseManager(), aiConfiguration: nil)
     }
@@ -44,6 +50,10 @@ public class WritersApp {
         self.encouragementService = EncouragementService()
         self.versionControl = DoltVersionControlService(databaseManager: databaseManager)
         self.guiService = nil
+        self.prospectDatabase = ProspectDatabase()
+        self.browserService = BrowserService()
+        self.gmailService = nil
+        self.activeCoworkSession = nil
         let aiSvc = aiConfiguration.map { AIService(configuration: $0) }
         self.aiService = aiSvc
         if let svc = aiSvc {
@@ -1134,6 +1144,140 @@ public class WritersApp {
     ) async throws -> HarnessResult {
         let harness = try createMultiAgentHarness(configuration: configuration)
         return try await harness.run(plan: plan)
+    }
+
+    // MARK: - Cowork Mode
+
+    /// Enable Gmail integration using the given OAuth 2.0 bearer token.
+    /// The token must be obtained by the caller (e.g. from the GMAIL_OAUTH_TOKEN env var).
+    public func enableGmail(oauthToken: String) {
+        self.gmailService = GmailService(oauthToken: oauthToken)
+    }
+
+    /// Disable Gmail integration.
+    public func disableGmail() {
+        self.gmailService = nil
+    }
+
+    /// Whether Gmail is available for this session.
+    public var isGmailEnabled: Bool {
+        return gmailService != nil
+    }
+
+    // MARK: Cowork session lifecycle
+
+    /// Start a new cowork session, replacing any active one.
+    @discardableResult
+    public func startCoworkSession() -> CoworkSession {
+        let session = CoworkSession()
+        self.activeCoworkSession = session
+        return session
+    }
+
+    /// End the active cowork session and return its summary.
+    @discardableResult
+    public func endCoworkSession() -> CoworkSession? {
+        guard var session = activeCoworkSession else { return nil }
+        session.endedAt = Date()
+        self.activeCoworkSession = nil
+        return session
+    }
+
+    // MARK: Prospect facade
+
+    /// Add a new prospect to the database.
+    @discardableResult
+    public func addProspect(
+        name: String,
+        email: String,
+        company: String? = nil,
+        role: String? = nil,
+        notes: String = "",
+        tags: [String] = []
+    ) -> Prospect {
+        let prospect = Prospect(
+            name: name,
+            email: email,
+            company: company,
+            role: role,
+            notes: notes,
+            tags: tags
+        )
+        prospectDatabase.addProspect(prospect)
+        activeCoworkSession?.prospectsAdded += 1
+        return prospect
+    }
+
+    public func getAllProspects() -> [Prospect] {
+        return prospectDatabase.getAllProspects()
+    }
+
+    public func getProspects(withStatus status: ProspectStatus) -> [Prospect] {
+        return prospectDatabase.getProspects(withStatus: status)
+    }
+
+    public func searchProspects(query: String) -> [Prospect] {
+        return prospectDatabase.searchProspects(query: query)
+    }
+
+    public func updateProspectStatus(id: UUID, status: ProspectStatus) throws {
+        try prospectDatabase.updateProspectStatus(id: id, status: status)
+        if status == .contacted || status == .replied || status == .meeting {
+            activeCoworkSession?.prospectsContacted += 1
+        }
+    }
+
+    public func deleteProspect(id: UUID) {
+        prospectDatabase.deleteProspect(id: id)
+    }
+
+    public func getProspectStats() -> [ProspectStatus: Int] {
+        return prospectDatabase.getStats()
+    }
+
+    // MARK: Gmail facade
+
+    /// List Gmail inbox messages.
+    /// - Throws: `CoworkError.gmailNotEnabled` if Gmail has not been enabled.
+    public func listGmailMessages(maxResults: Int = 20, query: String? = nil) async throws -> [GmailMessage] {
+        guard let gmail = gmailService else { throw CoworkError.gmailNotEnabled }
+        return try await gmail.listMessages(maxResults: maxResults, query: query)
+    }
+
+    /// Send an email via Gmail and record it in the active cowork session.
+    /// - Throws: `CoworkError.gmailNotEnabled` if Gmail has not been enabled.
+    @discardableResult
+    public func sendGmail(draft: GmailDraft) async throws -> String {
+        guard let gmail = gmailService else { throw CoworkError.gmailNotEnabled }
+        let sentId = try await gmail.sendMessage(draft: draft)
+        activeCoworkSession?.emailsSent += 1
+        return sentId
+    }
+
+    /// Mark a Gmail message as read.
+    /// - Throws: `CoworkError.gmailNotEnabled` if Gmail has not been enabled.
+    public func markGmailAsRead(id: String) async throws {
+        guard let gmail = gmailService else { throw CoworkError.gmailNotEnabled }
+        try await gmail.markAsRead(id: id)
+    }
+
+    // MARK: Browser facade
+
+    /// Fetch a URL and return its plain-text content.
+    public func browseURL(_ urlString: String) async throws -> BrowsedPage {
+        let page = try await browserService.fetch(urlString: urlString)
+        activeCoworkSession?.pagesResearched += 1
+        return page
+    }
+
+    /// Return all pages browsed in this session.
+    public func getBrowsingHistory() -> [BrowsedPage] {
+        return browserService.history
+    }
+
+    /// Clear the browsing history.
+    public func clearBrowsingHistory() {
+        browserService.clearHistory()
     }
 }
 

--- a/Sources/WritersAppCLI/main.swift
+++ b/Sources/WritersAppCLI/main.swift
@@ -286,6 +286,15 @@ struct WritersAppCLI {
             print("ⓘ Ragie disabled (set RAGIE_API_KEY to enable document retrieval)")
         }
 
+        // Initialize Gmail for Cowork Mode if OAuth token is present
+        if let gmailToken = ProcessInfo.processInfo.environment["GMAIL_OAUTH_TOKEN"], !gmailToken.isEmpty {
+            app.enableGmail(oauthToken: gmailToken)
+            print("✓ Cowork Mode: Gmail enabled")
+        } else {
+            print("ⓘ Cowork Mode: Gmail disabled (set GMAIL_OAUTH_TOKEN to enable)")
+        }
+        print("✓ Cowork Mode: Prospect database and browser research ready")
+
         // Initialize Claude Memory plugin
         do {
             try await app.enableMemoryPlugin()
@@ -399,6 +408,21 @@ struct WritersAppCLI {
                 print("97. List Ragie Documents")
                 print("98. Check Ragie Document Status")
             }
+
+            print("\nCowork Mode (Gmail + Prospects + Browser):")
+            print("100. Start Cowork Session")
+            print("101. End Cowork Session")
+            print("102. Add Prospect")
+            print("103. List Prospects")
+            print("104. Search Prospects")
+            print("105. Update Prospect Status")
+            print("106. Prospect Pipeline Stats")
+            if app.isGmailEnabled {
+                print("107. View Gmail Inbox")
+                print("108. Send Email")
+            }
+            print("109. Research URL (Browser)")
+            print("110. View Browsing History")
 
             print("\n0. Exit")
             print()
@@ -546,6 +570,28 @@ struct WritersAppCLI {
                 await listRagieDocuments(app: app)
             case 98:
                 await checkRagieDocumentStatus(app: app)
+            case 100:
+                startCoworkSession(app: app)
+            case 101:
+                endCoworkSession(app: app)
+            case 102:
+                addProspect(app: app)
+            case 103:
+                listProspects(app: app)
+            case 104:
+                searchProspects(app: app)
+            case 105:
+                updateProspectStatus(app: app)
+            case 106:
+                viewProspectPipelineStats(app: app)
+            case 107:
+                await viewGmailInbox(app: app)
+            case 108:
+                await sendGmail(app: app)
+            case 109:
+                await researchURL(app: app)
+            case 110:
+                viewBrowsingHistory(app: app)
             case 0:
                 await app.shutdownPlugins()
                 running = false
@@ -3924,4 +3970,295 @@ func deleteKanbanBoardCLI(app: WritersApp) {
     }
     app.deleteKanbanBoard(id: board.id)
     print("\n✓ Kanban board '\(board.name)' deleted.")
+}
+
+// MARK: - Cowork Mode Handlers
+
+func startCoworkSession(app: WritersApp) {
+    let session = app.startCoworkSession()
+    let formatter = DateFormatter()
+    formatter.dateStyle = .none
+    formatter.timeStyle = .short
+    print("\n=== Cowork Session Started ===")
+    print("Session ID: \(session.id.uuidString.prefix(8))...")
+    print("Started at: \(formatter.string(from: session.startedAt))")
+    print("Gmail:     \(app.isGmailEnabled ? "enabled" : "disabled")")
+    print("Prospects: ready")
+    print("Browser:   ready")
+}
+
+func endCoworkSession(app: WritersApp) {
+    guard let session = app.endCoworkSession() else {
+        print("\nNo active cowork session.")
+        return
+    }
+    print("\n=== Cowork Session Summary ===")
+    let mins = session.durationMinutes.map { String(format: "%.0f min", $0) } ?? "unknown"
+    print("Duration:            \(mins)")
+    print("Emails sent:         \(session.emailsSent)")
+    print("Prospects added:     \(session.prospectsAdded)")
+    print("Prospects contacted: \(session.prospectsContacted)")
+    print("Pages researched:    \(session.pagesResearched)")
+    print("\nSession ended. Great work!")
+}
+
+func addProspect(app: WritersApp) {
+    print("\n=== Add Prospect ===\n")
+    print("Name: ", terminator: "")
+    guard let name = readLine(), !name.isEmpty else {
+        print("Name cannot be empty.")
+        return
+    }
+    print("Email: ", terminator: "")
+    guard let email = readLine(), !email.isEmpty, email.contains("@") else {
+        print("Invalid email address.")
+        return
+    }
+    print("Company (optional): ", terminator: "")
+    let company = readLine().flatMap { $0.isEmpty ? nil : $0 }
+    print("Role (e.g. publisher, agent, client): ", terminator: "")
+    let role = readLine().flatMap { $0.isEmpty ? nil : $0 }
+    print("Notes (optional): ", terminator: "")
+    let notes = readLine() ?? ""
+    print("Tags (comma-separated, optional): ", terminator: "")
+    let tagsInput = readLine() ?? ""
+    let tags = tagsInput.isEmpty ? [] : tagsInput.components(separatedBy: ",").map {
+        $0.trimmingCharacters(in: .whitespaces)
+    }
+
+    let prospect = app.addProspect(
+        name: name, email: email, company: company, role: role, notes: notes, tags: tags
+    )
+    print("\n✓ Prospect '\(prospect.name)' added (ID: \(prospect.id.uuidString.prefix(8))...)")
+}
+
+func listProspects(app: WritersApp) {
+    print("\n=== Prospect Database ===\n")
+    let prospects = app.getAllProspects()
+    if prospects.isEmpty {
+        print("No prospects yet. Add some with option 102.")
+        return
+    }
+    for prospect in prospects {
+        let company = prospect.company.map { " @ \($0)" } ?? ""
+        let role = prospect.role.map { " [\($0)]" } ?? ""
+        print("• \(prospect.name)\(company)\(role)")
+        print("  Email:  \(prospect.email)")
+        print("  Status: \(prospect.status.displayName)")
+        if !prospect.notes.isEmpty {
+            print("  Notes:  \(prospect.notes)")
+        }
+        if !prospect.tags.isEmpty {
+            print("  Tags:   \(prospect.tags.joined(separator: ", "))")
+        }
+        if let contacted = prospect.lastContactedAt {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .short
+            formatter.timeStyle = .none
+            print("  Last contacted: \(formatter.string(from: contacted))")
+        }
+        print()
+    }
+    print("Total: \(prospects.count) prospect(s)")
+}
+
+func searchProspects(app: WritersApp) {
+    print("\n=== Search Prospects ===\n")
+    print("Search query: ", terminator: "")
+    guard let query = readLine(), !query.isEmpty else {
+        print("Query cannot be empty.")
+        return
+    }
+    let results = app.searchProspects(query: query)
+    if results.isEmpty {
+        print("No prospects match '\(query)'.")
+        return
+    }
+    print("\nFound \(results.count) result(s):\n")
+    for prospect in results {
+        let company = prospect.company.map { " @ \($0)" } ?? ""
+        print("• \(prospect.name)\(company) — \(prospect.email) [\(prospect.status.displayName)]")
+    }
+}
+
+func updateProspectStatus(app: WritersApp) {
+    print("\n=== Update Prospect Status ===\n")
+    let prospects = app.getAllProspects()
+    if prospects.isEmpty {
+        print("No prospects found.")
+        return
+    }
+    for (i, p) in prospects.enumerated() {
+        print("\(i + 1). \(p.name) [\(p.status.displayName)]")
+    }
+    print("\nSelect prospect (1-\(prospects.count)): ", terminator: "")
+    guard let input = readLine(), let choice = Int(input),
+          choice >= 1, choice <= prospects.count else {
+        print("Invalid selection.")
+        return
+    }
+    let prospect = prospects[choice - 1]
+    let statuses = ProspectStatus.allCases
+    print("\nSelect new status:")
+    for (i, status) in statuses.enumerated() {
+        let marker = status == prospect.status ? " (current)" : ""
+        print("\(i + 1). \(status.displayName)\(marker)")
+    }
+    print("Choice (1-\(statuses.count)): ", terminator: "")
+    guard let statusInput = readLine(), let statusChoice = Int(statusInput),
+          statusChoice >= 1, statusChoice <= statuses.count else {
+        print("Invalid selection.")
+        return
+    }
+    let newStatus = statuses[statusChoice - 1]
+    do {
+        try app.updateProspectStatus(id: prospect.id, status: newStatus)
+        print("\n✓ \(prospect.name) status updated to \(newStatus.displayName)")
+    } catch {
+        print("Error: \(error.localizedDescription)")
+    }
+}
+
+func viewProspectPipelineStats(app: WritersApp) {
+    print("\n=== Prospect Pipeline ===\n")
+    let stats = app.getProspectStats()
+    let total = stats.values.reduce(0, +)
+    if total == 0 {
+        print("No prospects in the pipeline yet.")
+        return
+    }
+    for status in ProspectStatus.allCases {
+        let count = stats[status] ?? 0
+        let bar = String(repeating: "█", count: count)
+        let label = status.displayName.padding(toLength: 20, withPad: " ", startingAt: 0)
+        print("\(label) \(String(format: "%3d", count))  \(bar)")
+    }
+    print("\nTotal: \(total) prospect(s)")
+}
+
+func viewGmailInbox(app: WritersApp) async {
+    print("\n=== Gmail Inbox ===\n")
+    guard app.isGmailEnabled else {
+        print("Gmail is not enabled. Set GMAIL_OAUTH_TOKEN and restart.")
+        return
+    }
+    print("Max results (default 10): ", terminator: "")
+    let maxInput = readLine() ?? ""
+    let maxResults = Int(maxInput) ?? 10
+    print("Search query (optional, e.g. 'from:agent@example.com'): ", terminator: "")
+    let query = readLine().flatMap { $0.isEmpty ? nil : $0 }
+
+    do {
+        let messages = try await app.listGmailMessages(maxResults: maxResults, query: query)
+        if messages.isEmpty {
+            print("No messages found.")
+            return
+        }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        print("\nFetched \(messages.count) message(s):\n")
+        for (i, msg) in messages.enumerated() {
+            let readMarker = msg.isRead ? "  " : "● "
+            print("\(readMarker)\(i + 1). \(msg.subject.isEmpty ? "(no subject)" : msg.subject)")
+            print("     From: \(msg.from)")
+            print("     Date: \(formatter.string(from: msg.date))")
+            if !msg.snippet.isEmpty {
+                let preview = String(msg.snippet.prefix(80))
+                print("     \(preview)…")
+            }
+            print()
+        }
+    } catch {
+        print("Error fetching inbox: \(error.localizedDescription)")
+    }
+}
+
+func sendGmail(app: WritersApp) async {
+    print("\n=== Send Email via Gmail ===\n")
+    guard app.isGmailEnabled else {
+        print("Gmail is not enabled. Set GMAIL_OAUTH_TOKEN and restart.")
+        return
+    }
+    print("To: ", terminator: "")
+    guard let to = readLine(), !to.isEmpty, to.contains("@") else {
+        print("Invalid recipient address.")
+        return
+    }
+    print("Subject: ", terminator: "")
+    guard let subject = readLine(), !subject.isEmpty else {
+        print("Subject cannot be empty.")
+        return
+    }
+    print("Body (end with a line containing only '.'): ")
+    var lines: [String] = []
+    while let line = readLine() {
+        if line == "." { break }
+        lines.append(line)
+    }
+    let body = lines.joined(separator: "\n")
+    print("\nSend to \(to) with subject '\(subject)'? (y/N): ", terminator: "")
+    guard let confirm = readLine(), confirm.lowercased() == "y" else {
+        print("Send cancelled.")
+        return
+    }
+    let draft = GmailDraft(to: to, subject: subject, body: body)
+    do {
+        let sentId = try await app.sendGmail(draft: draft)
+        print("\n✓ Email sent (ID: \(sentId.prefix(16))...)")
+    } catch {
+        print("Error sending email: \(error.localizedDescription)")
+    }
+}
+
+func researchURL(app: WritersApp) async {
+    print("\n=== Research URL ===\n")
+    print("Enter URL to fetch (https://...): ", terminator: "")
+    guard let urlString = readLine(), !urlString.isEmpty else {
+        print("URL cannot be empty.")
+        return
+    }
+    do {
+        print("Fetching \(urlString)...")
+        let page = try await app.browseURL(urlString)
+        print("\n--- \(page.title) ---")
+        print("URL: \(page.url)")
+        // Show first 40 non-empty lines
+        let lines = page.textContent.components(separatedBy: "\n").prefix(40)
+        for line in lines {
+            print(line)
+        }
+        let totalLines = page.textContent.components(separatedBy: "\n").count
+        if totalLines > 40 {
+            print("\n[... \(totalLines - 40) more lines — saved to browsing history]")
+        }
+        print("\n✓ Page saved to browsing history (\(page.textContent.count) chars)")
+    } catch {
+        print("Error: \(error.localizedDescription)")
+    }
+}
+
+func viewBrowsingHistory(app: WritersApp) {
+    print("\n=== Browsing History ===\n")
+    let history = app.getBrowsingHistory()
+    if history.isEmpty {
+        print("No pages browsed this session. Use option 109 to research a URL.")
+        return
+    }
+    let formatter = DateFormatter()
+    formatter.dateStyle = .none
+    formatter.timeStyle = .short
+    for (i, page) in history.enumerated() {
+        print("\(i + 1). \(page.title)")
+        print("   URL:     \(page.url)")
+        print("   Fetched: \(formatter.string(from: page.fetchedAt))")
+        print("   Size:    \(page.textContent.count) chars")
+        print()
+    }
+    print("Total: \(history.count) page(s)")
+    print("\nClear history? (y/N): ", terminator: "")
+    if let input = readLine(), input.lowercased() == "y" {
+        app.clearBrowsingHistory()
+        print("✓ Browsing history cleared.")
+    }
 }


### PR DESCRIPTION
Integrates three tools solo founders need in a single writing session:

- ProspectDatabase: in-memory CRUD for tracking publishers, agents,
  clients, and collaborators with pipeline status (new → contacted →
  replied → meeting → declined → converted)
- GmailService: REST client for Gmail API (list inbox, send, mark read)
  authenticated via GMAIL_OAUTH_TOKEN env var
- BrowserService: fetches URLs and strips HTML to plain text for
  research; keeps a per-session browsing history
- CoworkSession: tracks emails sent, prospects added/contacted, pages
  researched across the session with duration summary on end
- WritersApp facade exposes enable/disable for Gmail and full CRUD for
  all three subsystems
- CLI menu items 100-110 with start/end session, add/list/search/status
  prospects, pipeline stats, Gmail inbox/send, URL research, history

https://claude.ai/code/session_01XrA9tssDAF8EusUsDiKe7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cowork Mode: New session-based workflow to track productivity metrics including emails sent, prospects added, and pages researched
  * Prospect Pipeline: Add, search, and update contact statuses across a customizable sales pipeline with statistics
  * Gmail Integration: List emails, compose and send drafts, and manage read status within the app
  * Web Research Tools: Fetch and browse URLs with automatic history tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->