### PR TITLE
Implement vision content support for computer use service

### DIFF
--- a/Sources/WritersApp/Services/AIService.swift
+++ b/Sources/WritersApp/Services/AIService.swift
@@ -535,6 +535,68 @@ public class AIService {
         return toolResults
     }
 
+    // MARK: - Vision Support
+
+    /// Get AI assistance with vision content (text + image)
+    ///
+    /// Sends a request to Claude with both text and image data. Useful for computer use,
+    /// screenshot analysis, and other vision-based tasks.
+    /// - Parameters:
+    ///   - text: The text prompt or instruction
+    ///   - imageBase64: Base64-encoded image data
+    ///   - mediaType: MIME type of the image (e.g., "image/png", "image/jpeg")
+    /// - Returns: The assistant's text response
+    public func getAssistanceWithVision(
+        text: String,
+        imageBase64: String,
+        mediaType: String = "image/png"
+    ) async throws -> String {
+        guard let url = URL(string: apiURL) else {
+            throw AIServiceError.invalidURL
+        }
+
+        let contentArray: [[String: Any]] = [
+            [
+                "type": "image",
+                "source": [
+                    "type": "base64",
+                    "media_type": mediaType,
+                    "data": imageBase64
+                ]
+            ],
+            [
+                "type": "text",
+                "text": text
+            ]
+        ]
+
+        let messages: [[String: Any]] = [
+            ["role": "user", "content": contentArray]
+        ]
+
+        let request = try buildAPIURLRequest(url: url, messages: messages, toolDefinitions: [])
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AIServiceError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw AIServiceError.apiError(statusCode: httpResponse.statusCode, message: "Request failed")
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]] else {
+            throw AIServiceError.invalidResponseFormat
+        }
+
+        guard let responseText = extractText(from: content) else {
+            throw AIServiceError.invalidResponseFormat
+        }
+
+        return responseText
+    }
+
     // MARK: - Batch Operations
 
     /// Process multiple requests in batch

--- a/Sources/WritersApp/Services/ComputerUseService.swift
+++ b/Sources/WritersApp/Services/ComputerUseService.swift
@@ -78,18 +78,24 @@ public class ComputerUseService {
         previousActions: [ComputerUseAction],
         configuration: ComputerUseConfiguration
     ) async throws -> ActionResponse {
-        // Build a simple text-based prompt for the AI
+        // Build the prompt for the AI
         let history = previousActions.map { $0.action.rawValue }.joined(separator: ", ")
         let prompt = """
         Task: \(task)
         Display: \(configuration.displayWidth)x\(configuration.displayHeight)
         Previous actions: \(history.isEmpty ? "none" : history)
-        Current screenshot (base64): [screenshot provided]
-        What is the next action to complete the task? Reply with "DONE" if finished.
+
+        Analyze the current screenshot and determine the next action to complete the task.
+        Reply with "DONE" if the task is finished, or describe the next action to take.
         """
-        // TODO: Send screenshot as vision content when implementing full Anthropic computer use API integration
-        _ = screenshot
-        let response = try await aiService.continueWriting(text: prompt)
+
+        // Send screenshot as vision content using the Anthropic API vision capabilities
+        let response = try await aiService.getAssistanceWithVision(
+            text: prompt,
+            imageBase64: screenshot,
+            mediaType: "image/png"
+        )
+
         if response.uppercased().contains("DONE") {
             return ActionResponse(action: nil, response: response, isDone: true)
         }


### PR DESCRIPTION
Add getAssistanceWithVision method to AIService to support sending images
as vision content to Claude API. Update ComputerUseService to use the new
vision-enabled method instead of just mentioning screenshots in text.

This allows Claude to actually see and analyze screenshots during computer
use tasks rather than just having them described in the prompt.

https://claude.ai/code/session_011dFA3zrDAr5SbQcr1yzJpP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vision-enabled AI assistance: The AI assistant can now analyze images and screenshots in real-time alongside text inputs. Visual content is processed to provide more intelligent and contextually aware responses, enabling the system to understand your content better and deliver improved assistance for your writing and creative tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->