### PR TITLE
feat: Hermes agent V0.9.0 — tone, idea favouriting, session stats, and tests

### DIFF
--- a/Sources/WritersApp/Models/HermesModels.swift
+++ b/Sources/WritersApp/Models/HermesModels.swift
@@ -2,6 +2,42 @@ import Foundation
 
 // MARK: - Hermes Models
 
+/// The emotional tone Hermes should adopt when generating ideas
+public enum HermesTone: String, Codable, CaseIterable {
+    case inspirational
+    case provocative
+    case calm
+    case energetic
+    case whimsical
+    case dark
+    case playful
+
+    public var displayName: String {
+        switch self {
+        case .inspirational: return "Inspirational"
+        case .provocative:   return "Provocative"
+        case .calm:          return "Calm"
+        case .energetic:     return "Energetic"
+        case .whimsical:     return "Whimsical"
+        case .dark:          return "Dark"
+        case .playful:       return "Playful"
+        }
+    }
+
+    /// One-line prompt fragment injected into the Hermes persona when this tone is active
+    var promptHint: String {
+        switch self {
+        case .inspirational: return "Be uplifting and motivating — make the writer feel that anything is possible."
+        case .provocative:   return "Be bold and challenging — push conventional boundaries and subvert expectations."
+        case .calm:          return "Be measured and serene — offer ideas with quiet confidence and gentle clarity."
+        case .energetic:     return "Be vivid and fast-paced — flood the writer with momentum and excitement."
+        case .whimsical:     return "Be playfully strange and dreamy — let ideas drift into the unexpected."
+        case .dark:          return "Be brooding and intense — explore shadow, conflict, and moral complexity."
+        case .playful:       return "Be lighthearted and witty — ideas should sparkle with humour and fun."
+        }
+    }
+}
+
 /// The type of creative idea Hermes generated
 public enum HermesIdeaType: String, Codable, CaseIterable {
     case plotHook = "plotHook"
@@ -34,23 +70,27 @@ public struct HermesIdea: Identifiable, Codable {
     public let description: String
     public let ideaType: HermesIdeaType
     public let timestamp: Date
+    /// Whether the writer has marked this idea as a favourite for later use
+    public var isFavorite: Bool
 
     public init(
         id: UUID = UUID(),
         title: String,
         description: String,
         ideaType: HermesIdeaType,
-        timestamp: Date = Date()
+        timestamp: Date = Date(),
+        isFavorite: Bool = false
     ) {
         self.id = id
         self.title = title
         self.description = description
         self.ideaType = ideaType
         self.timestamp = timestamp
+        self.isFavorite = isFavorite
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, title, description, ideaType, timestamp
+        case id, title, description, ideaType, timestamp, isFavorite
     }
 
     public init(from decoder: Decoder) throws {
@@ -62,12 +102,10 @@ public struct HermesIdea: Identifiable, Codable {
         let timestampString = try container.decode(String.self, forKey: .timestamp)
         let formatter = ISO8601DateFormatter()
         timestamp = formatter.date(from: timestampString) ?? Date()
+        // Backward-compatible: existing payloads without this key default to false
+        isFavorite = (try? container.decodeIfPresent(Bool.self, forKey: .isFavorite)) ?? false
     }
 
-    /// Encodes the instance into the provided encoder.
-    /// 
-    /// Encodes `id`, `title`, `description`, and `ideaType` using their coding keys and serializes `timestamp` as an ISO-8601 formatted string.
-    /// - Parameter encoder: The encoder to write this value into.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
@@ -76,6 +114,7 @@ public struct HermesIdea: Identifiable, Codable {
         try container.encode(ideaType, forKey: .ideaType)
         let formatter = ISO8601DateFormatter()
         try container.encode(formatter.string(from: timestamp), forKey: .timestamp)
+        try container.encode(isFavorite, forKey: .isFavorite)
     }
 }
 
@@ -87,6 +126,8 @@ public struct HermesContext: Codable {
     public let characters: [String]
     public let themes: [String]
     public let documentId: UUID?
+    /// Desired emotional tone for generated ideas. When set, Hermes adjusts its voice accordingly.
+    public let tone: HermesTone?
 
     public init(
         genre: String = "",
@@ -94,7 +135,8 @@ public struct HermesContext: Codable {
         currentScene: String = "",
         characters: [String] = [],
         themes: [String] = [],
-        documentId: UUID? = nil
+        documentId: UUID? = nil,
+        tone: HermesTone? = nil
     ) {
         self.genre = genre
         self.logline = logline
@@ -102,6 +144,7 @@ public struct HermesContext: Codable {
         self.characters = characters
         self.themes = themes
         self.documentId = documentId
+        self.tone = tone
     }
 }
 
@@ -236,6 +279,42 @@ public struct HermesResponse {
         self.message = message
         self.ideas = ideas
         self.timestamp = timestamp
+    }
+}
+
+/// Aggregated statistics for a completed or in-progress Hermes session
+public struct HermesSessionStats {
+    /// Identifier of the session these stats describe
+    public let sessionId: UUID
+    /// Total number of messages exchanged (user + Hermes combined)
+    public let messageCount: Int
+    /// Total number of ideas generated across all Hermes messages
+    public let totalIdeas: Int
+    /// Number of ideas the writer has marked as favourite
+    public let favoriteCount: Int
+    /// Idea count broken down by `HermesIdeaType`
+    public let ideaCountByType: [HermesIdeaType: Int]
+    /// Wall-clock duration from session start to the last message, in seconds
+    public let sessionDuration: TimeInterval
+    /// Mean number of ideas per Hermes message (0 when no Hermes messages exist)
+    public let averageIdeasPerMessage: Double
+
+    public init(
+        sessionId: UUID,
+        messageCount: Int,
+        totalIdeas: Int,
+        favoriteCount: Int,
+        ideaCountByType: [HermesIdeaType: Int],
+        sessionDuration: TimeInterval,
+        averageIdeasPerMessage: Double
+    ) {
+        self.sessionId = sessionId
+        self.messageCount = messageCount
+        self.totalIdeas = totalIdeas
+        self.favoriteCount = favoriteCount
+        self.ideaCountByType = ideaCountByType
+        self.sessionDuration = sessionDuration
+        self.averageIdeasPerMessage = averageIdeasPerMessage
     }
 }
 

--- a/Sources/WritersApp/Models/HermesModels.swift
+++ b/Sources/WritersApp/Models/HermesModels.swift
@@ -25,7 +25,7 @@ public enum HermesTone: String, Codable, CaseIterable {
     }
 
     /// One-line prompt fragment injected into the Hermes persona when this tone is active
-    var promptHint: String {
+    public var promptHint: String {
         switch self {
         case .inspirational: return "Be uplifting and motivating — make the writer feel that anything is possible."
         case .provocative:   return "Be bold and challenging — push conventional boundaries and subvert expectations."
@@ -103,7 +103,7 @@ public struct HermesIdea: Identifiable, Codable {
         let formatter = ISO8601DateFormatter()
         timestamp = formatter.date(from: timestampString) ?? Date()
         // Backward-compatible: existing payloads without this key default to false
-        isFavorite = (try? container.decodeIfPresent(Bool.self, forKey: .isFavorite)) ?? false
+        isFavorite = try container.decodeIfPresent(Bool.self, forKey: .isFavorite) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -283,7 +283,8 @@ public struct HermesResponse {
 }
 
 /// Aggregated statistics for a completed or in-progress Hermes session
-public struct HermesSessionStats {
+public struct HermesSessionStats: Codable, Identifiable {
+    public var id: UUID { sessionId }
     /// Identifier of the session these stats describe
     public let sessionId: UUID
     /// Total number of messages exchanged (user + Hermes combined)

--- a/Sources/WritersApp/Services/HermesService.swift
+++ b/Sources/WritersApp/Services/HermesService.swift
@@ -103,11 +103,19 @@ public class HermesService {
         trimHistory(&session)
         let userPrompt = buildUserPrompt(userText: prompt, session: session)
 
+        // Append tone instruction when the session context specifies one
+        let effectivePersona: String
+        if let tone = session.context.tone {
+            effectivePersona = hermesPersona + "\n\nTone instruction: \(tone.promptHint)"
+        } else {
+            effectivePersona = hermesPersona
+        }
+
         // Call Claude with the Hermes persona as the system prompt and tool support
         let rawResponse: String
         do {
             rawResponse = try await aiService.performAgentTaskWithTools(
-                systemPrompt: hermesPersona,
+                systemPrompt: effectivePersona,
                 userPrompt: userPrompt,
                 tools: WritingToolExecutor.tools,
                 toolExecutor: toolExecutor
@@ -160,6 +168,81 @@ public class HermesService {
         return try await generateIdeas(expansionPrompt, in: &session)
     }
 
+    // MARK: - Idea Queries
+
+    /// Returns every idea from all Hermes messages in the session, optionally filtered by type.
+    /// - Parameters:
+    ///   - session: The session to scan.
+    ///   - type: When non-nil, only ideas whose `ideaType` matches are included.
+    /// - Returns: A flat array of `HermesIdea` in chronological order.
+    public func getAllIdeas(from session: HermesSession, filteredBy type: HermesIdeaType? = nil) -> [HermesIdea] {
+        let all = session.messages
+            .filter { $0.role == .hermes }
+            .flatMap { $0.ideas }
+        guard let filter = type else { return all }
+        return all.filter { $0.ideaType == filter }
+    }
+
+    /// Returns every idea in the session that has been marked as a favourite.
+    /// - Parameter session: The session to scan.
+    /// - Returns: A flat array of favourite `HermesIdea` in chronological order.
+    public func getFavorites(from session: HermesSession) -> [HermesIdea] {
+        return session.messages
+            .filter { $0.role == .hermes }
+            .flatMap { $0.ideas }
+            .filter { $0.isFavorite }
+    }
+
+    /// Marks an idea in the session as a favourite.
+    /// - Parameters:
+    ///   - ideaId: UUID of the idea to favourite.
+    ///   - session: The session containing the idea; mutated in place.
+    /// - Throws: `HermesError.ideaNotFound(id:)` if no idea with that UUID exists.
+    public func favoriteIdea(_ ideaId: UUID, in session: inout HermesSession) throws {
+        try setFavoriteFlag(ideaId: ideaId, value: true, in: &session)
+    }
+
+    /// Removes the favourite mark from an idea in the session.
+    /// - Parameters:
+    ///   - ideaId: UUID of the idea to un-favourite.
+    ///   - session: The session containing the idea; mutated in place.
+    /// - Throws: `HermesError.ideaNotFound(id:)` if no idea with that UUID exists.
+    public func unfavoriteIdea(_ ideaId: UUID, in session: inout HermesSession) throws {
+        try setFavoriteFlag(ideaId: ideaId, value: false, in: &session)
+    }
+
+    // MARK: - Session Statistics
+
+    /// Computes aggregated statistics for a Hermes session.
+    /// - Parameter session: The session to analyse.
+    /// - Returns: A `HermesSessionStats` value summarising the session.
+    public func getSessionStats(from session: HermesSession) -> HermesSessionStats {
+        let hermesMessages = session.messages.filter { $0.role == .hermes }
+        let allIdeas = hermesMessages.flatMap { $0.ideas }
+
+        var countByType: [HermesIdeaType: Int] = [:]
+        var favoriteCount = 0
+        for idea in allIdeas {
+            countByType[idea.ideaType, default: 0] += 1
+            if idea.isFavorite { favoriteCount += 1 }
+        }
+
+        let duration = session.lastMessageAt.timeIntervalSince(session.startedAt)
+        let avgIdeas = hermesMessages.isEmpty
+            ? 0.0
+            : Double(allIdeas.count) / Double(hermesMessages.count)
+
+        return HermesSessionStats(
+            sessionId: session.id,
+            messageCount: session.messages.count,
+            totalIdeas: allIdeas.count,
+            favoriteCount: favoriteCount,
+            ideaCountByType: countByType,
+            sessionDuration: max(0, duration),
+            averageIdeasPerMessage: avgIdeas
+        )
+    }
+
     // MARK: - History
 
     /// Retrieve the session's message history in chronological order.
@@ -174,6 +257,38 @@ public class HermesService {
     ///   - session: The `HermesSession` whose message history will be removed.
     public func clearHistory(for session: inout HermesSession) {
         session.messages.removeAll()
+    }
+
+    /// Sets the `isFavorite` flag on an idea inside the session, rebuilding the containing message in place.
+    /// - Parameters:
+    ///   - ideaId: UUID of the idea to update.
+    ///   - value: The new favourite flag value.
+    ///   - session: The session to mutate.
+    /// - Throws: `HermesError.ideaNotFound(id:)` if the idea does not exist in the session.
+    private func setFavoriteFlag(ideaId: UUID, value: Bool, in session: inout HermesSession) throws {
+        for msgIdx in session.messages.indices {
+            let message = session.messages[msgIdx]
+            guard let ideaIdx = message.ideas.firstIndex(where: { $0.id == ideaId }) else { continue }
+            let existing = message.ideas[ideaIdx]
+            var updatedIdeas = message.ideas
+            updatedIdeas[ideaIdx] = HermesIdea(
+                id: existing.id,
+                title: existing.title,
+                description: existing.description,
+                ideaType: existing.ideaType,
+                timestamp: existing.timestamp,
+                isFavorite: value
+            )
+            session.messages[msgIdx] = HermesMessage(
+                id: message.id,
+                role: message.role,
+                content: message.content,
+                ideas: updatedIdeas,
+                timestamp: message.timestamp
+            )
+            return
+        }
+        throw HermesError.ideaNotFound(id: ideaId)
     }
 
     /// Validates a user prompt by trimming surrounding whitespace and enforcing non-empty text and the configured maximum length.

--- a/Sources/WritersApp/Services/HermesService.swift
+++ b/Sources/WritersApp/Services/HermesService.swift
@@ -268,17 +268,10 @@ public class HermesService {
     private func setFavoriteFlag(ideaId: UUID, value: Bool, in session: inout HermesSession) throws {
         for msgIdx in session.messages.indices {
             let message = session.messages[msgIdx]
+            guard message.role == .hermes else { continue }
             guard let ideaIdx = message.ideas.firstIndex(where: { $0.id == ideaId }) else { continue }
-            let existing = message.ideas[ideaIdx]
             var updatedIdeas = message.ideas
-            updatedIdeas[ideaIdx] = HermesIdea(
-                id: existing.id,
-                title: existing.title,
-                description: existing.description,
-                ideaType: existing.ideaType,
-                timestamp: existing.timestamp,
-                isFavorite: value
-            )
+            updatedIdeas[ideaIdx].isFavorite = value
             session.messages[msgIdx] = HermesMessage(
                 id: message.id,
                 role: message.role,

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -288,10 +288,55 @@ public class WritersApp {
     }
 
     /// Ends the active Hermes ideation session.
-    /// 
+    ///
     /// If Hermes is not enabled or no session is active, this does nothing.
     public func endHermesSession() {
         hermesService?.endSession()
+    }
+
+    /// Returns all ideas generated in the session, optionally filtered by type.
+    /// - Parameters:
+    ///   - session: The session to query.
+    ///   - type: When non-nil, only ideas of this type are returned.
+    /// - Returns: A flat array of `HermesIdea` in chronological order.
+    public func getAllIdeas(from session: HermesSession, filteredBy type: HermesIdeaType? = nil) -> [HermesIdea] {
+        return hermesService?.getAllIdeas(from: session, filteredBy: type) ?? []
+    }
+
+    /// Returns all ideas the writer has marked as favourite in the session.
+    /// - Parameter session: The session to query.
+    /// - Returns: A flat array of favourite `HermesIdea` in chronological order.
+    public func getFavorites(from session: HermesSession) -> [HermesIdea] {
+        return hermesService?.getFavorites(from: session) ?? []
+    }
+
+    /// Marks a specific idea in the session as a favourite.
+    /// - Parameters:
+    ///   - ideaId: UUID of the idea to favourite.
+    ///   - session: The session containing the idea; mutated in place.
+    /// - Throws: `HermesError.aiNotAvailable` if Hermes is not enabled.
+    ///           `HermesError.ideaNotFound(id:)` if the idea does not exist.
+    public func favoriteIdea(ideaId: UUID, in session: inout HermesSession) throws {
+        guard let service = hermesService else { throw HermesError.aiNotAvailable }
+        try service.favoriteIdea(ideaId, in: &session)
+    }
+
+    /// Removes the favourite mark from a specific idea in the session.
+    /// - Parameters:
+    ///   - ideaId: UUID of the idea to un-favourite.
+    ///   - session: The session containing the idea; mutated in place.
+    /// - Throws: `HermesError.aiNotAvailable` if Hermes is not enabled.
+    ///           `HermesError.ideaNotFound(id:)` if the idea does not exist.
+    public func unfavoriteIdea(ideaId: UUID, in session: inout HermesSession) throws {
+        guard let service = hermesService else { throw HermesError.aiNotAvailable }
+        try service.unfavoriteIdea(ideaId, in: &session)
+    }
+
+    /// Computes aggregated statistics for a Hermes session.
+    /// - Parameter session: The session to analyse.
+    /// - Returns: A `HermesSessionStats` value, or `nil` if Hermes is not enabled.
+    public func getHermesSessionStats(from session: HermesSession) -> HermesSessionStats? {
+        return hermesService?.getSessionStats(from: session)
     }
 
     // MARK: - Settings Management

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -2904,6 +2904,381 @@ final class WritingAdvisorTests: XCTestCase {
     }
 }
 
+// MARK: - Hermes Agent V0.9.0 Tests
+
+final class HermesAgentTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Build a HermesService backed by an in-memory stub (no real AI calls).
+    private func makeService() -> HermesService {
+        let app = WritersApp()
+        // Use the real initialiser path — AI is nil so we test the non-AI layers.
+        return HermesService(
+            aiService: AIService(configuration: AIConfiguration(apiKey: "test-key")),
+            documentManager: app.documentManager,
+            templateManager: app.templateManager
+        )
+    }
+
+    /// Inject a pre-built HermesMessage with known ideas into a session.
+    private func sessionWith(ideas: [HermesIdea]) -> HermesSession {
+        let message = HermesMessage(role: .hermes, content: "Here are some ideas.", ideas: ideas)
+        return HermesSession(messages: [message])
+    }
+
+    private func makeIdea(
+        type: HermesIdeaType = .plotHook,
+        title: String = "Test Idea",
+        isFavorite: Bool = false
+    ) -> HermesIdea {
+        HermesIdea(title: title, description: "A description.", ideaType: type, isFavorite: isFavorite)
+    }
+
+    // MARK: - HermesTone
+
+    func testHermesToneDisplayNamesAreNonEmpty() {
+        for tone in HermesTone.allCases {
+            XCTAssertFalse(tone.displayName.isEmpty, "\(tone) displayName must not be empty")
+        }
+    }
+
+    func testHermesTonePromptHintsAreNonEmpty() {
+        for tone in HermesTone.allCases {
+            XCTAssertFalse(tone.promptHint.isEmpty, "\(tone) promptHint must not be empty")
+        }
+    }
+
+    func testHermesToneRoundTripsViaCodable() throws {
+        for tone in HermesTone.allCases {
+            let data = try JSONEncoder().encode(tone)
+            let decoded = try JSONDecoder().decode(HermesTone.self, from: data)
+            XCTAssertEqual(decoded, tone)
+        }
+    }
+
+    func testHermesContextStoresTone() {
+        let ctx = HermesContext(genre: "Fantasy", tone: .dark)
+        XCTAssertEqual(ctx.tone, .dark)
+    }
+
+    func testHermesContextDefaultToneIsNil() {
+        let ctx = HermesContext()
+        XCTAssertNil(ctx.tone)
+    }
+
+    // MARK: - HermesIdea isFavorite
+
+    func testHermesIdeaDefaultIsNotFavorite() {
+        let idea = makeIdea()
+        XCTAssertFalse(idea.isFavorite)
+    }
+
+    func testHermesIdeaIsFavoriteRoundTripsCodable() throws {
+        let idea = makeIdea(isFavorite: true)
+        let data = try JSONEncoder().encode(idea)
+        let decoded = try JSONDecoder().decode(HermesIdea.self, from: data)
+        XCTAssertTrue(decoded.isFavorite)
+    }
+
+    func testHermesIdeaIsFavoriteDefaultsFalseOnLegacyPayload() throws {
+        // Simulate a payload that was encoded before isFavorite existed
+        let json = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "title": "Old Idea",
+            "description": "Desc",
+            "ideaType": "plotHook",
+            "timestamp": "2026-01-01T00:00:00Z"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(HermesIdea.self, from: json)
+        XCTAssertFalse(decoded.isFavorite, "Legacy payloads without isFavorite must default to false")
+    }
+
+    // MARK: - parseIdeas
+
+    func testParseIdeasExtractsNumberedList() {
+        let service = makeService()
+        let raw = """
+        1. [PLOT HOOK] The Dragon's Secret
+           A dragon guards a secret about the hero's true identity.
+        2. [CHARACTER TRAIT] Reluctant Hero
+           She never wanted to save the world — until today.
+        """
+        let ideas = service.parseIdeas(from: raw)
+        XCTAssertEqual(ideas.count, 2)
+        XCTAssertEqual(ideas[0].title, "The Dragon's Secret")
+        XCTAssertEqual(ideas[0].ideaType, .plotHook)
+        XCTAssertEqual(ideas[1].title, "Reluctant Hero")
+        XCTAssertEqual(ideas[1].ideaType, .characterTrait)
+    }
+
+    func testParseIdeasWithNoTagDefaultsToPlotHook() {
+        let service = makeService()
+        let raw = "1. An Untitled Mystery\n   Somebody stole the crown jewels."
+        let ideas = service.parseIdeas(from: raw)
+        XCTAssertEqual(ideas.count, 1)
+        XCTAssertEqual(ideas[0].ideaType, .plotHook)
+    }
+
+    func testParseIdeasReturnsEmptyForNonListInput() {
+        let service = makeService()
+        let ideas = service.parseIdeas(from: "Just a plain sentence with no numbered list.")
+        XCTAssertTrue(ideas.isEmpty)
+    }
+
+    func testParseIdeasStripsBoldMarkdown() {
+        let service = makeService()
+        let raw = "1. **Bold Title**\n   Description here."
+        let ideas = service.parseIdeas(from: raw)
+        XCTAssertEqual(ideas.count, 1)
+        XCTAssertFalse(ideas[0].title.contains("*"), "Bold markdown asterisks must be stripped")
+    }
+
+    // MARK: - getAllIdeas
+
+    func testGetAllIdeasReturnsFlatList() {
+        let service = makeService()
+        let ideas = [
+            makeIdea(type: .plotHook, title: "Hook"),
+            makeIdea(type: .setting, title: "City")
+        ]
+        let session = sessionWith(ideas: ideas)
+        XCTAssertEqual(service.getAllIdeas(from: session).count, 2)
+    }
+
+    func testGetAllIdeasFilteredByType() {
+        let service = makeService()
+        let ideas = [
+            makeIdea(type: .plotHook, title: "Hook"),
+            makeIdea(type: .setting, title: "City"),
+            makeIdea(type: .setting, title: "Forest")
+        ]
+        let session = sessionWith(ideas: ideas)
+        let filtered = service.getAllIdeas(from: session, filteredBy: .setting)
+        XCTAssertEqual(filtered.count, 2)
+        XCTAssertTrue(filtered.allSatisfy { $0.ideaType == .setting })
+    }
+
+    func testGetAllIdeasFilteredReturnsEmptyWhenNoMatch() {
+        let service = makeService()
+        let ideas = [makeIdea(type: .plotHook)]
+        let session = sessionWith(ideas: ideas)
+        let filtered = service.getAllIdeas(from: session, filteredBy: .dialogue)
+        XCTAssertTrue(filtered.isEmpty)
+    }
+
+    // MARK: - favoriteIdea / unfavoriteIdea
+
+    func testFavoriteIdeaSetsFlagOnCorrectIdea() throws {
+        let service = makeService()
+        let target = makeIdea(type: .twist, title: "Big Twist")
+        var session = sessionWith(ideas: [target, makeIdea(title: "Other")])
+
+        try service.favoriteIdea(target.id, in: &session)
+
+        let updated = service.getAllIdeas(from: session).first { $0.id == target.id }
+        XCTAssertEqual(updated?.isFavorite, true)
+    }
+
+    func testUnfavoriteIdeaClearsFlagOnCorrectIdea() throws {
+        let service = makeService()
+        let target = makeIdea(isFavorite: true)
+        var session = sessionWith(ideas: [target])
+
+        try service.unfavoriteIdea(target.id, in: &session)
+
+        let updated = service.getAllIdeas(from: session).first { $0.id == target.id }
+        XCTAssertEqual(updated?.isFavorite, false)
+    }
+
+    func testFavoriteIdeaThrowsIdeaNotFound() {
+        let service = makeService()
+        var session = sessionWith(ideas: [makeIdea()])
+        XCTAssertThrowsError(try service.favoriteIdea(UUID(), in: &session)) { error in
+            guard case HermesError.ideaNotFound = error else {
+                XCTFail("Expected HermesError.ideaNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testUnfavoriteIdeaThrowsIdeaNotFound() {
+        let service = makeService()
+        var session = sessionWith(ideas: [makeIdea()])
+        XCTAssertThrowsError(try service.unfavoriteIdea(UUID(), in: &session)) { error in
+            guard case HermesError.ideaNotFound = error else {
+                XCTFail("Expected HermesError.ideaNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testFavoritingOneIdeaDoesNotAffectOthers() throws {
+        let service = makeService()
+        let a = makeIdea(title: "Alpha")
+        let b = makeIdea(title: "Beta")
+        var session = sessionWith(ideas: [a, b])
+
+        try service.favoriteIdea(a.id, in: &session)
+
+        let bAfter = service.getAllIdeas(from: session).first { $0.id == b.id }
+        XCTAssertEqual(bAfter?.isFavorite, false, "Un-targeted idea must remain un-favourited")
+    }
+
+    // MARK: - getFavorites
+
+    func testGetFavoritesReturnsOnlyFavoritedIdeas() throws {
+        let service = makeService()
+        let fav = makeIdea(title: "Keep Me", isFavorite: true)
+        let notFav = makeIdea(title: "Skip Me", isFavorite: false)
+        let session = sessionWith(ideas: [fav, notFav])
+
+        let favorites = service.getFavorites(from: session)
+        XCTAssertEqual(favorites.count, 1)
+        XCTAssertEqual(favorites[0].id, fav.id)
+    }
+
+    func testGetFavoritesReturnsEmptyWhenNoneFavorited() {
+        let service = makeService()
+        let session = sessionWith(ideas: [makeIdea(), makeIdea()])
+        XCTAssertTrue(service.getFavorites(from: session).isEmpty)
+    }
+
+    // MARK: - getSessionStats
+
+    func testSessionStatsIdeasCount() {
+        let service = makeService()
+        let session = sessionWith(ideas: [
+            makeIdea(type: .plotHook),
+            makeIdea(type: .setting),
+            makeIdea(type: .plotHook)
+        ])
+        let stats = service.getSessionStats(from: session)
+        XCTAssertEqual(stats.totalIdeas, 3)
+        XCTAssertEqual(stats.ideaCountByType[.plotHook], 2)
+        XCTAssertEqual(stats.ideaCountByType[.setting], 1)
+    }
+
+    func testSessionStatsFavoriteCount() {
+        let service = makeService()
+        let session = sessionWith(ideas: [
+            makeIdea(isFavorite: true),
+            makeIdea(isFavorite: false),
+            makeIdea(isFavorite: true)
+        ])
+        let stats = service.getSessionStats(from: session)
+        XCTAssertEqual(stats.favoriteCount, 2)
+    }
+
+    func testSessionStatsMessageCount() {
+        let service = makeService()
+        let userMsg = HermesMessage(role: .user, content: "Give me ideas")
+        let hermesMsg = HermesMessage(role: .hermes, content: "Here:", ideas: [makeIdea()])
+        var session = HermesSession()
+        session.messages = [userMsg, hermesMsg]
+        let stats = service.getSessionStats(from: session)
+        XCTAssertEqual(stats.messageCount, 2)
+    }
+
+    func testSessionStatsAverageIdeasPerMessageEmptySession() {
+        let service = makeService()
+        let session = HermesSession()
+        let stats = service.getSessionStats(from: session)
+        XCTAssertEqual(stats.averageIdeasPerMessage, 0.0)
+    }
+
+    func testSessionStatsAverageIdeasPerMessage() {
+        let service = makeService()
+        let session = sessionWith(ideas: [makeIdea(), makeIdea(), makeIdea()])
+        let stats = service.getSessionStats(from: session)
+        // 3 ideas in 1 Hermes message
+        XCTAssertEqual(stats.averageIdeasPerMessage, 3.0, accuracy: 0.001)
+    }
+
+    func testSessionStatsDurationIsNonNegative() {
+        let service = makeService()
+        let session = HermesSession()
+        let stats = service.getSessionStats(from: session)
+        XCTAssertGreaterThanOrEqual(stats.sessionDuration, 0.0)
+    }
+
+    // MARK: - clearHistory
+
+    func testClearHistoryRemovesAllMessages() {
+        let service = makeService()
+        let msg = HermesMessage(role: .user, content: "Hello")
+        var session = HermesSession(messages: [msg])
+        service.clearHistory(for: &session)
+        XCTAssertTrue(session.messages.isEmpty)
+    }
+
+    // MARK: - startHermesSession / endHermesSession (via WritersApp)
+
+    func testStartHermesSessionThrowsWhenAINotEnabled() {
+        let noAIApp = WritersApp()
+        XCTAssertThrowsError(try noAIApp.startHermesSession()) { error in
+            guard case HermesError.aiNotAvailable = error else {
+                XCTFail("Expected HermesError.aiNotAvailable")
+                return
+            }
+        }
+    }
+
+    func testGetAllIdeasViaWritersAppWithNoAIReturnsEmpty() {
+        let noAIApp = WritersApp()
+        let session = HermesSession()
+        XCTAssertTrue(noAIApp.getAllIdeas(from: session).isEmpty)
+    }
+
+    func testGetFavoritesViaWritersAppWithNoAIReturnsEmpty() {
+        let noAIApp = WritersApp()
+        let session = HermesSession()
+        XCTAssertTrue(noAIApp.getFavorites(from: session).isEmpty)
+    }
+
+    func testFavoriteIdeaThrowsAINotAvailableWhenNoAI() {
+        let noAIApp = WritersApp()
+        var session = HermesSession()
+        XCTAssertThrowsError(try noAIApp.favoriteIdea(ideaId: UUID(), in: &session)) { error in
+            guard case HermesError.aiNotAvailable = error else {
+                XCTFail("Expected HermesError.aiNotAvailable")
+                return
+            }
+        }
+    }
+
+    func testGetHermesSessionStatsReturnsNilWhenNoAI() {
+        let noAIApp = WritersApp()
+        let session = HermesSession()
+        XCTAssertNil(noAIApp.getHermesSessionStats(from: session))
+    }
+
+    // MARK: - HermesSessionStats
+
+    func testHermesSessionStatsInitialiserStoresAllFields() {
+        let id = UUID()
+        let byType: [HermesIdeaType: Int] = [.plotHook: 3, .twist: 1]
+        let stats = HermesSessionStats(
+            sessionId: id,
+            messageCount: 4,
+            totalIdeas: 4,
+            favoriteCount: 1,
+            ideaCountByType: byType,
+            sessionDuration: 120.0,
+            averageIdeasPerMessage: 2.0
+        )
+        XCTAssertEqual(stats.sessionId, id)
+        XCTAssertEqual(stats.messageCount, 4)
+        XCTAssertEqual(stats.totalIdeas, 4)
+        XCTAssertEqual(stats.favoriteCount, 1)
+        XCTAssertEqual(stats.ideaCountByType[.plotHook], 3)
+        XCTAssertEqual(stats.sessionDuration, 120.0, accuracy: 0.001)
+        XCTAssertEqual(stats.averageIdeasPerMessage, 2.0, accuracy: 0.001)
+    }
+}
+
 // MARK: - Test Helpers
 
 private class MockComputerUseExecutor: ComputerUseExecutor {

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -2910,10 +2910,11 @@ final class HermesAgentTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Build a HermesService backed by an in-memory stub (no real AI calls).
+    /// Build a HermesService for tests that only exercise non-AI behavior (parsing, session utilities).
     private func makeService() -> HermesService {
-        let app = WritersApp()
-        // Use the real initialiser path — AI is nil so we test the non-AI layers.
+        let app = WritersApp(databasePath: ":memory:")
+        // Use a real AIService configured with a test key; these tests avoid network calls
+        // by only exercising non-AI code paths.
         return HermesService(
             aiService: AIService(configuration: AIConfiguration(apiKey: "test-key")),
             documentManager: app.documentManager,


### PR DESCRIPTION
- Add HermesTone enum (7 tones: inspirational, provocative, calm, energetic,
  whimsical, dark, playful) with displayName and promptHint; injected into the
  Hermes system persona when set on HermesContext
- Add tone field to HermesContext (optional, backward-compatible)
- Add isFavorite flag to HermesIdea with backward-compatible Codable decode
- Add HermesSessionStats struct (messageCount, totalIdeas, favoriteCount,
  ideaCountByType, sessionDuration, averageIdeasPerMessage)
- Add HermesService methods: getAllIdeas(from:filteredBy:), getFavorites(from:),
  favoriteIdea(_:in:), unfavoriteIdea(_:in:), getSessionStats(from:)
- Expose all new methods on the WritersApp facade
- Add HermesAgentTests with 30 unit tests covering parseIdeas, favouriting,
  filtering, stats, tone, Codable round-trips, and error paths

https://claude.ai/code/session_014kGFMjxPHnEhepv75dBShR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select emotional tone to customize Hermes idea generation.
  * Mark generated ideas as favorites for quick access.
  * View session statistics including idea counts, favorites, and generation metrics.
  * Filter and retrieve ideas by type.

* **Tests**
  * Added comprehensive test coverage for Hermes features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->