### PR TITLE
Reorganize Claude setup for clarity and consistency

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,65 @@
+# Claude Code Setup for friendly-outlaw
+
+This directory organizes how Claude Code helps with this Swift writers app. Think of it as your project's AI assistant playbook.
+
+## Quick Orientation
+
+**When you start working on a task:**
+
+1. **Ask** — Describe what you want to build or fix
+2. **Plan** — Claude consults the knowledge base via the knowledge-advisor agent
+3. **Execute** — You approve, Claude writes code and runs tests
+
+This setup makes sure Claude knows your patterns before writing anything.
+
+## What's in Here
+
+| File/Dir | Purpose |
+|----------|---------|
+| **workflow.md** | How the ask → plan → execute flow works (start here if new) |
+| **project.md** | Quick intro: what friendly-outlaw is, how to build/test/run |
+| **agents/** | Specialized workers (knowledge-advisor reads rules, swift-debugger fixes errors, etc.) |
+| **skills/** | Step-by-step workflows for common tasks (add template, add AI feature, etc.) |
+| **knowledge/** | Structured standards (Swift rules, architecture patterns, security, templates, testing) |
+| **hooks/** | Scripts that run automatically (e.g., on session start: installs dependencies, builds project) |
+| **settings.json** | Permissions and hook registration |
+
+## Using This Setup
+
+### Before Making a Code Change
+Use the **knowledge-advisor** subagent to retrieve applicable standards:
+
+> "I'm adding a new async method to AIService for generating chapter outlines. What standards apply?"
+
+It reads the relevant knowledge files and returns a focused checklist. This takes 10 seconds and prevents rework.
+
+### For Common Tasks
+Use **skills** — they're step-by-step guides:
+- Adding a new writing template? → use `add-template` skill
+- Implementing a new AI feature? → use `add-ai-feature` skill
+- Extending version control? → use `add-version-control-op` skill
+
+### For Debugging
+Use **subagents** to stay focused:
+- Build errors or crashes? → **swift-debugger** agent
+- Want a second opinion on your code? → **swift-code-reviewer** agent
+- Need to run tests? → **test-runner** agent
+
+### Standards & Knowledge Base
+All project rules live in `.claude/knowledge/` as JSON files — no guessing, no outdated docs:
+
+- **swift.json** — Naming, optionals, async/await, no external deps
+- **architecture.json** — Manager/service patterns, how to add features
+- **security.json** — No hardcoded secrets, input validation, network policy
+- **templates.json** — Placeholder format, category rules
+- **testing.json** — What to test, AI method guidance
+
+## One More Thing
+
+The session-start hook (`.claude/hooks/session-start.sh`) runs automatically on Ctrl+K web sessions. It installs dependencies, builds the project, and sets up plugins. If something fails, it'll tell you—then you can fix and retry.
+
+## Need Help?
+
+- General Claude Code questions? → `/help`
+- Found a bug or have feedback? → Report at https://github.com/anthropics/claude-code/issues
+- Want to understand the project better? → Read `project.md` next

--- a/.claude/project.md
+++ b/.claude/project.md
@@ -1,0 +1,241 @@
+# friendly-outlaw: Quick Project Reference
+
+A Swift application for writers with templates, documents, AI assistance, version control, and plugins.
+
+## What It Is
+
+**friendly-outlaw** helps writers with:
+- **Templates** — Pre-built writing structures (novel outline, screenplay, blog post, etc.)
+- **Documents** — Create and track documents, word count, export to Markdown/HTML/plaintext
+- **AI Writing Assistant** — Claude integration for brainstorming, editing, outlining (opt-in)
+- **Issues** — Track problems per-document with status and priority
+- **Kanban Boards** — Organize writing tasks in columns (backlog → planning → running → review → done)
+- **Version Control** — Git-like branching, commits, diffs for document snapshots
+- **Plugins** — Extensible architecture for memory storage, MCP servers, custom actions
+- **Analytics** — Track writing streaks, sessions, productivity
+
+**Platform:** macOS 13+, iOS 16+ | **Language:** Swift 5.9+ | **Build:** SPM
+
+---
+
+## Quick Commands
+
+```bash
+# Build
+swift build                    # Debug build
+swift build -c release         # Release build
+
+# Test
+swift test                     # All tests (88+)
+swift test --verbose          # Detailed output
+
+# Run
+swift run WritersAppCLI       # Interactive CLI
+ANTHROPIC_API_KEY=sk-... \
+  swift run WritersAppCLI    # With AI features enabled
+
+# Clean
+swift package clean           # Remove build artifacts
+```
+
+---
+
+## Project Structure
+
+```
+Sources/WritersApp/
+├── Models/                   # Data structures (Template, Document, Issue, etc.)
+├── Services/                 # Business logic (TemplateManager, AIService, etc.)
+├── Plugins/                  # Plugin architecture (Plugin protocol, PluginManager)
+├── Views/                    # UI (Metal dashboard, iPad views)
+└── Extensions/               # Utilities (string placeholders, Codable types)
+
+Tests/WritersAppTests/
+└── WritersAppTests.swift     # 88+ tests for all major components
+
+.claude/
+├── knowledge/                # Structured standards (JSON)
+├── agents/                   # Subagents (knowledge-advisor, debugger, etc.)
+├── skills/                   # Workflows (add-template, add-ai-feature, etc.)
+└── hooks/                    # Automation (session-start.sh installs deps)
+```
+
+---
+
+## Key Concepts
+
+### Managers
+Classes that handle CRUD and business logic. All are properties of the main `WritersApp` class:
+- `TemplateManager` — Template library (7 defaults)
+- `DocumentManager` — Document lifecycle + statistics
+- `IssueManager` — Issue tracking per-document
+- `KanbanManager` — Kanban boards and task workflow
+- `WritingGoalManager` — Goal creation + progress tracking
+- `PluginManager` — Singleton, manages all plugins
+
+### Services
+Classes that handle complex operations:
+- `AIService` — Anthropic API calls, tool loop
+- `DatabaseManager` — SQLite persistence (sessions, suggestions, version control)
+- `DoltVersionControlService` — Git-like branching, commits, diffs, time-travel
+- `EncouragementService` — Motivational messages
+- `ProductivityAnalytics` — Writing statistics and trends
+
+### The Plugin System
+Extensible via the `Plugin` protocol:
+- `ClaudeMemoryPlugin` — Key/value memory store
+- `MCPClient` — Model Context Protocol client for external MCP servers
+- User can add more plugins — they all implement `initialize()`, `shutdown()`, `execute(action:)`
+
+### Version Control (Dolt-Inspired)
+Git-like semantics for documents:
+- Branches, commits, diffs, merges
+- Time-travel queries (`query(asOf:)`)
+- Merge strategies: fast-forward and 3-way merge
+- Backed by SQLite for durability
+
+### AI Tool Loop
+Claude can call built-in tools during responses:
+- `get_word_count` — Count words
+- `search_documents` — Search by query
+- `get_document` — Fetch document by title
+- `calculate_reading_time` — Reading time estimate (200 wpm)
+- `list_templates` — List templates by category
+
+---
+
+## Code Conventions
+
+### Naming
+- Methods: verbs (`createDocument`, `improveText`, `brainstormIdeas`)
+- Properties: descriptive (`wordCount`, `isAchieved`, `progressPercentage`)
+- Status/state: `updateIssueStatus`, `checkoutBranch`, `moveKanbanTask`
+
+### Organization
+- `// MARK: - Section Name` for code sections
+- Public interfaces first, private implementation below
+- Conform types to `Codable` for JSON serialization
+
+### Async/Await
+- All AI and plugin operations are `async throws`
+- Typed errors: `AIError`, `DatabaseError`, `VersionControlError`, `PluginError`
+
+### No External Dependencies
+The main library (`WritersApp`) has zero external dependencies:
+- No third-party HTTP clients (use `URLSession`)
+- No JSON parsing libraries (use `Codable`)
+- Only dependency: `CSQLite` (system library wrapping sqlite3)
+
+---
+
+## High-Level APIs
+
+### Initialization
+```swift
+let app = WritersApp()                                    // No AI
+let app = WritersApp(aiConfiguration: config)            // With AI
+let app = WritersApp(databasePath: ":memory:")            // In-memory DB (tests)
+```
+
+### Documents
+```swift
+app.createDocumentFromTemplate(templateId:values:)
+app.createBlankDocument(title:category:)
+app.exportDocument(id:format:)  // .markdown, .plainText, .html
+app.documentManager.getStatistics()
+```
+
+### AI (requires `enableAI()` first)
+```swift
+app.enableAI(configuration: config, userId: userId)
+
+// High-level helpers
+try await app.continueDocument(documentId:context:appendToDocument:)
+try await app.improveDocument(documentId:context:replaceContent:)
+try await app.brainstormIdeas(topic:context:)
+try await app.generateOutline(concept:context:)
+
+// With tool loop (Claude calls your built-in tools)
+try await app.getAIAssistanceWithTools(
+    documentId:type:context:maxIterations:
+)
+```
+
+### Issues
+```swift
+app.issueManager.createIssue(documentId:title:description:status:priority:)
+app.issueManager.getIssues(forDocument:)
+app.issueManager.updateIssueStatus(id:status:)
+app.issueManager.reopenIssue(id:)  // Clears resolvedAt timestamp
+```
+
+### Kanban
+```swift
+app.kanbanManager.createKanbanBoard(name:description:)
+app.kanbanManager.createKanbanTask(boardId:title:description:column:)
+app.kanbanManager.moveKanbanTask(id:toColumn:)
+app.kanbanManager.advanceKanbanTask(id:)  // Next column in workflow
+```
+
+### Version Control
+```swift
+try app.versionControl.initializeDefaultBranch()
+try app.versionControl.commit(message:author:timestamp:)
+try app.versionControl.checkoutBranch(name:)
+try app.versionControl.diff(from:to:)
+try app.versionControl.merge(source:strategy:)
+try app.versionControl.query(asOf:)  // Time-travel queries
+```
+
+### Plugins
+```swift
+try await app.enableMemoryPlugin()
+try await app.storeMemory(key:value:category:tags:importance:)
+try await app.retrieveMemory(key:)
+try await app.searchMemories(query:category:limit:)
+```
+
+---
+
+## Development Notes
+
+- **AI is optional** — Works without `ANTHROPIC_API_KEY` (graceful degradation)
+- **Database location** — Defaults to `~/Documents/writersapp.db`; override via init
+- **PluginManager is a singleton** — `PluginManager.shared` — register plugins once at app startup
+- **Dual-layer design** — IssueManager and version control are in-memory + SQLite-backed; keep them in sync via WritersApp facade
+- **Dates use ISO 8601** — For JSON serialization
+- **CSQLite is required** — `libsqlite3-dev` and `pkg-config` must be installed
+
+---
+
+## Testing
+
+Run all tests: `swift test`
+
+Coverage:
+- **Core:** templates, documents, word count, statistics, placeholders (8 tests)
+- **AI tool loop:** ToolDefinition, ToolUseBlock, ToolResult, WritingToolExecutor (16 tests)
+- **Issues:** CRUD, status/priority management, reopen (3 tests)
+- **Kanban:** boards, tasks, column workflow (18 tests)
+- **Version control:** branches, commits, diffs, merges, time-travel (17 tests)
+- **Total: 88+ tests**
+
+All tests must pass before committing.
+
+---
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Claude API key (enables AI features) |
+| `CLAUDE_PROJECT_DIR` | Project root (set by session-start hook) |
+
+---
+
+## Next Steps
+
+- **Starting a task?** → Read `.claude/workflow.md` to understand ask → plan → execute
+- **Adding a feature?** → Check `.claude/knowledge/` for standards first
+- **Debugging?** → Use the swift-debugger or test-runner agents
+- **Want examples?** → See `examples/` directory for Python Anthropic SDK usage

--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -1,0 +1,109 @@
+# The Ask → Plan → Execute Workflow
+
+This is how you work effectively with Claude in this project.
+
+## The Pattern
+
+**Most tasks follow this flow:**
+
+```
+You: "I want to add [feature / fix / refactor]"
+    ↓
+Claude: "Here are the applicable standards from your knowledge base"
+    ↓
+You: "Looks good" or "Actually, change X to Y"
+    ↓
+Claude: Writes code, runs tests, commits
+```
+
+This workflow ensures Claude follows your project's patterns before writing anything.
+
+## Step 1: Ask
+
+Just say what you want. You don't need a perfect prompt. Examples:
+
+- "Add a new Kanban column type called 'testing'"
+- "Fix the document export to not drop metadata"
+- "Implement a new AI feature that generates pacing suggestions"
+
+## Step 2: Plan (Automatic)
+
+Claude consults the **knowledge-advisor** subagent to retrieve applicable standards. This happens automatically—no action needed from you. The agent reads:
+
+- `.claude/knowledge/swift.json` — If it's Swift code
+- `.claude/knowledge/architecture.json` — If it touches the app structure
+- `.claude/knowledge/security.json` — If it handles user data or API calls
+- `.claude/knowledge/testing.json` — Always (every change needs tests)
+- `.claude/knowledge/templates.json` — If it's about writing templates
+
+The advisor returns a **checklist of rules** specific to your task. This takes ~10 seconds.
+
+## Step 3: Approve
+
+Look at the plan. It should show:
+- What files will change
+- The applicable standards
+- A pre-commit checklist
+
+Say "looks good" or point out changes. You control the direction.
+
+## Step 4: Execute
+
+Claude writes code, tests it, and commits to your branch.
+
+---
+
+## When to Invoke Agents Directly
+
+Most tasks use the automatic knowledge-advisor. But for specific problems:
+
+| Situation | Invoke |
+|-----------|--------|
+| Build fails or crashes | **swift-debugger** — diagnoses the error |
+| Tests fail mysteriously | **test-runner** — runs tests, shows failures clearly |
+| Need code review | **swift-code-reviewer** — checks quality vs. conventions |
+| Adding a complex template | **template-designer** — guides you through structure |
+| Designing a feature | **Plan** subagent (if available) — works out architecture before coding |
+
+## When to Use Skills
+
+**Skills** are pre-built workflows for repetitive tasks:
+
+- `add-template` — Add a new writing template to TemplateManager
+- `add-ai-feature` — Implement a new AI capability (Claude method, system prompt, test)
+- `build-and-test` — Build the project and run tests, report failures
+- `add-version-control-op` — Extend DoltVersionControlService with a new operation
+
+Invoke with: "Use the X skill" or ask Claude to add a template (it auto-detects).
+
+---
+
+## Why This Works
+
+1. **Standards are in one place** — `.claude/knowledge/` — so they don't rot
+2. **Plans happen before code** — You review before anything changes
+3. **Agents specialize** — Knowledge-advisor, debugger, reviewer each do one job well
+4. **Async/repeatable** — Same pattern every time, no surprises
+
+## Example: Add a New Document Status
+
+**You:** "Add a new document status called 'archived'. Documents should be soft-deleted but queryable."
+
+**Claude:** Consults knowledge-advisor → returns applicable rules (architecture patterns, naming conventions, testing approach)
+
+**Claude's plan:**
+```
+Files to change:
+- Models/Document.swift (add .archived case to DocumentStatus enum)
+- Services/DocumentManager.swift (filter archived docs from list, add unarchive method)
+- Tests/WritersAppTests.swift (test soft-delete + unarchive)
+
+Applicable rules:
+- swift-naming: Status enums use .camelCase cases
+- arch-001: Always keep in-memory and DB in sync
+- test-001: Test the success path and edge cases
+```
+
+**You:** "Looks good" (or "Actually, also add a soft-delete timestamp")
+
+**Claude:** Makes the changes, tests, commits to your branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,25 @@
 # CLAUDE.md - AI Assistant Guide for friendly-outlaw
 
-This document provides essential context for AI assistants working with this codebase.
+## Start Here
 
-## Project Overview
+**New to the project?** Read in this order:
+1. `.claude/project.md` — What friendly-outlaw is and how to build/test/run it
+2. `.claude/workflow.md` — How to work with Claude: ask → plan → execute
+3. This file — Detailed API reference and architecture
 
-**friendly-outlaw** is a Swift application for writers featuring template management, document creation with word count tracking, AI-powered writing assistance (via Claude/Anthropic API), issue tracking, Kanban boards, version control, plugin architecture, and multi-format export capabilities.
+**Just need standards before writing code?** → Use the knowledge-advisor subagent:
 
-- **Type**: Swift library + CLI application
-- **Platforms**: macOS 13+, iOS 16+
-- **Swift Version**: 5.9+
-- **Dependencies**: `CSQLite` (system library wrapping `sqlite3`) for persistent storage
+> "I'm adding a new async method to AIService for generating chapter summaries. What standards apply?"
 
-## Quick Commands
+**Adding a new feature?** → Use a skill:
+- `add-template` — Add a writing template
+- `add-ai-feature` — Implement AI assistance
+- `add-version-control-op` — Extend version control
+- `build-and-test` — Build and run tests
 
-```bash
-# Build
-swift build                           # Debug build
-swift build -c release                # Release build
+## Quick Reference
 
-# Test
-swift test                            # Run all tests
-swift test --verbose                  # Verbose output
-
-# Run
-swift run WritersAppCLI               # Run CLI app
-ANTHROPIC_API_KEY="sk-..." swift run WritersAppCLI  # With AI features
-
-# Clean
-swift package clean                   # Remove build artifacts
-```
+See `.claude/project.md` for quick commands, APIs, and project structure. This document contains the detailed reference.
 
 ## Project Structure
 


### PR DESCRIPTION
Applied principles from "How I made my Claude setup more consistent":
- Split context into focused files (project overview, workflow, quick reference)
- CLAUDE.md is now a navigation hub pointing to specialized docs
- Created .claude/README.md explaining the overall setup
- Created .claude/workflow.md documenting the ask → plan → execute flow
- Created .claude/project.md with quick commands, APIs, and project reference

This separates concerns:
- New users start with .claude/README.md for orientation
- Technical reference stays in .claude/project.md
- The ask → plan → execute workflow is now explicit in .claude/workflow.md
- CLAUDE.md acts as a hub, not a monolithic reference
- Knowledge base (JSON standards) remains for structured rules

Benefits:
- Easier to onboard new developers
- Clear when to use knowledge-advisor vs. subagents vs. skills
- Standards stay organized and maintainable
- Less cognitive load per document

https://claude.ai/code/session_01SskFg2E99jYq8KghNuDe1m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive project documentation suite with operational guides and workflow standards
  * Established structured development workflow featuring planning, approval, and standards consultation steps
  * Added quick reference guides for project setup, architecture, and common development tasks
  * Provided clear configuration, dependency installation, and environment setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->