### PR TITLE
Fix Cowork Mode bugs: URL encoding, range trap, metric inflation, CLI gaps

### DIFF
--- a/Sources/WritersApp/Services/CoworkService.swift
+++ b/Sources/WritersApp/Services/CoworkService.swift
@@ -119,12 +119,15 @@ public class GmailService {
     /// - Returns: An array of `GmailMessage` objects for messages found (up to `maxResults`); individual messages that fail to fetch are skipped.
     /// - Throws: `CoworkError.invalidURL` if the request URL cannot be constructed; propagates errors thrown by the network request and message fetch operations.
     public func listMessages(maxResults: Int = 20, query: String? = nil) async throws -> [GmailMessage] {
-        var urlString = "\(baseURL)/messages?maxResults=\(maxResults)"
+        var components = URLComponents(string: "\(baseURL)/messages")
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "maxResults", value: String(maxResults))
+        ]
         if let q = query, !q.isEmpty {
-            let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? q
-            urlString += "&q=\(encoded)"
+            queryItems.append(URLQueryItem(name: "q", value: q))
         }
-        guard let url = URL(string: urlString) else { throw CoworkError.invalidURL }
+        components?.queryItems = queryItems
+        guard let url = components?.url else { throw CoworkError.invalidURL }
 
         let listData = try await performRequest(url: url, method: "GET")
         guard let json = try JSONSerialization.jsonObject(with: listData) as? [String: Any],
@@ -132,14 +135,25 @@ public class GmailService {
             return []
         }
 
-        var messages: [GmailMessage] = []
-        for item in messageList.prefix(maxResults) {
-            if let msgId = item["id"] as? String,
-               let msg = try? await getMessage(id: msgId) {
-                messages.append(msg)
+        let limitedMessages = Array(messageList.prefix(maxResults))
+        var messagesByIndex: [(Int, GmailMessage)] = []
+        messagesByIndex.reserveCapacity(limitedMessages.count)
+
+        try await withThrowingTaskGroup(of: (Int, GmailMessage).self) { group in
+            for (index, item) in limitedMessages.enumerated() {
+                guard let msgId = item["id"] as? String else { continue }
+                group.addTask {
+                    let message = try await self.getMessage(id: msgId)
+                    return (index, message)
+                }
+            }
+            for try await result in group {
+                messagesByIndex.append(result)
             }
         }
-        return messages
+
+        messagesByIndex.sort { $0.0 < $1.0 }
+        return messagesByIndex.map { $0.1 }
     }
 
     // MARK: Get single message
@@ -436,7 +450,7 @@ public class BrowserService {
                       options: .caseInsensitive,
                       range: start.lowerBound..<text.endIndex
                   ) {
-                text.removeSubrange(start.lowerBound...end.upperBound)
+                text.removeSubrange(start.lowerBound..<end.upperBound)
             }
         }
 

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -1582,8 +1582,12 @@ public class WritersApp {
     /// - Throws: Any error produced while updating the prospect status in the prospect database.
     /// - Note: If the new status is `.contacted`, `.replied`, or `.meeting`, increments `activeCoworkSession?.prospectsContacted` by 1.
     public func updateProspectStatus(id: UUID, status: ProspectStatus) throws {
+        let isContactStatus: (ProspectStatus) -> Bool = {
+            $0 == .contacted || $0 == .replied || $0 == .meeting
+        }
+        let previousStatus = prospectDatabase.getProspect(id: id)?.status
         try prospectDatabase.updateProspectStatus(id: id, status: status)
-        if status == .contacted || status == .replied || status == .meeting {
+        if isContactStatus(status) && !(previousStatus.map(isContactStatus) ?? false) {
             activeCoworkSession?.prospectsContacted += 1
         }
     }

--- a/Sources/WritersAppCLI/main.swift
+++ b/Sources/WritersAppCLI/main.swift
@@ -421,10 +421,11 @@ struct WritersAppCLI {
             print("106. Prospect Pipeline Stats")
             if app.isGmailEnabled {
                 print("107. View Gmail Inbox")
-                print("108. Send Email")
+                print("108. Mark Email as Read")
+                print("109. Send Email")
             }
-            print("109. Research URL (Browser)")
-            print("110. View Browsing History")
+            print("110. Research URL (Browser)")
+            print("111. View Browsing History")
 
             print("\n0. Exit")
             print()
@@ -589,10 +590,12 @@ struct WritersAppCLI {
             case 107:
                 await viewGmailInbox(app: app)
             case 108:
-                await sendGmail(app: app)
+                await markGmailMessageAsRead(app: app)
             case 109:
-                await researchURL(app: app)
+                await sendGmail(app: app)
             case 110:
+                await researchURL(app: app)
+            case 111:
                 viewBrowsingHistory(app: app)
             case 0:
                 await app.shutdownPlugins()
@@ -4172,9 +4175,18 @@ func viewGmailInbox(app: WritersApp) async {
         print("Gmail is not enabled. Set GMAIL_OAUTH_TOKEN and restart.")
         return
     }
-    print("Max results (default 10): ", terminator: "")
+    print("Max results (default 10, range 1-100): ", terminator: "")
     let maxInput = readLine() ?? ""
-    let maxResults = Int(maxInput) ?? 10
+    let trimmedMaxInput = maxInput.trimmingCharacters(in: .whitespacesAndNewlines)
+    let maxResults: Int
+    if trimmedMaxInput.isEmpty {
+        maxResults = 10
+    } else if let value = Int(trimmedMaxInput), (1...100).contains(value) {
+        maxResults = value
+    } else {
+        print("Invalid max results. Please enter a number between 1 and 100.")
+        return
+    }
     print("Search query (optional, e.g. 'from:agent@example.com'): ", terminator: "")
     let query = readLine().flatMap { $0.isEmpty ? nil : $0 }
 
@@ -4204,8 +4216,27 @@ func viewGmailInbox(app: WritersApp) async {
     }
 }
 
+func markGmailMessageAsRead(app: WritersApp) async {
+    print("\n=== Mark Email as Read ===\n")
+    guard app.isGmailEnabled else {
+        print("Gmail is not enabled. Set GMAIL_OAUTH_TOKEN and restart.")
+        return
+    }
+    print("Enter message ID to mark as read: ", terminator: "")
+    guard let msgId = readLine(), !msgId.isEmpty else {
+        print("Message ID cannot be empty.")
+        return
+    }
+    do {
+        try await app.markGmailAsRead(id: msgId)
+        print("\n✓ Message \(String(msgId.prefix(16)))... marked as read.")
+    } catch {
+        print("Error: \(error.localizedDescription)")
+    }
+}
+
 /// Presents an interactive CLI flow to compose and send an email through the app's Gmail integration.
-/// 
+///
 /// Prompts for recipient, subject, and a multi-line body (terminated by a line containing only `.`), validates the recipient contains `@`, asks for confirmation, and then sends the message using the app's Gmail service. If Gmail is not enabled the function returns early. Prints success with a shortened message ID or an error description on failure.
 func sendGmail(app: WritersApp) async {
     print("\n=== Send Email via Gmail ===\n")

--- a/Tests/WritersAppTests/CoworkModeTests.swift
+++ b/Tests/WritersAppTests/CoworkModeTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+@testable import WritersApp
+
+final class CoworkModeTests: XCTestCase {
+    var app: WritersApp!
+
+    override func setUp() {
+        super.setUp()
+        app = WritersApp()
+    }
+
+    override func tearDown() {
+        app = nil
+        super.tearDown()
+    }
+
+    // MARK: - ProspectDatabase CRUD
+
+    func testAddAndGetProspect() {
+        let prospect = app.addProspect(
+            name: "Jane Agent",
+            email: "jane@agency.com",
+            company: "Top Agency",
+            role: "Literary Agent",
+            notes: "Loves sci-fi",
+            tags: ["sci-fi", "literary"]
+        )
+        XCTAssertEqual(prospect.name, "Jane Agent")
+        XCTAssertEqual(prospect.email, "jane@agency.com")
+        XCTAssertEqual(prospect.company, "Top Agency")
+        XCTAssertEqual(prospect.role, "Literary Agent")
+        XCTAssertEqual(prospect.status, .new)
+        XCTAssertEqual(prospect.notes, "Loves sci-fi")
+        XCTAssertEqual(prospect.tags, ["sci-fi", "literary"])
+
+        let fetched = app.prospectDatabase.getProspect(id: prospect.id)
+        XCTAssertNotNil(fetched)
+        XCTAssertEqual(fetched?.id, prospect.id)
+    }
+
+    func testGetAllProspects() {
+        XCTAssertTrue(app.getAllProspects().isEmpty)
+        _ = app.addProspect(name: "Alice", email: "alice@example.com")
+        _ = app.addProspect(name: "Bob", email: "bob@example.com")
+        XCTAssertEqual(app.getAllProspects().count, 2)
+    }
+
+    func testDeleteProspect() {
+        let prospect = app.addProspect(name: "Temp", email: "temp@example.com")
+        XCTAssertEqual(app.getAllProspects().count, 1)
+        app.deleteProspect(id: prospect.id)
+        XCTAssertTrue(app.getAllProspects().isEmpty)
+    }
+
+    func testSearchProspects() {
+        _ = app.addProspect(name: "Alice Publisher", email: "alice@press.com", company: "Big Press")
+        _ = app.addProspect(name: "Bob Agent", email: "bob@agency.com", notes: "science fiction fan")
+        _ = app.addProspect(name: "Carol Editor", email: "carol@mag.com")
+
+        let byName = app.searchProspects(query: "alice")
+        XCTAssertEqual(byName.count, 1)
+        XCTAssertEqual(byName.first?.name, "Alice Publisher")
+
+        let byCompany = app.searchProspects(query: "big press")
+        XCTAssertEqual(byCompany.count, 1)
+
+        let byNotes = app.searchProspects(query: "science fiction")
+        XCTAssertEqual(byNotes.count, 1)
+        XCTAssertEqual(byNotes.first?.name, "Bob Agent")
+
+        let noMatch = app.searchProspects(query: "zzznomatch")
+        XCTAssertTrue(noMatch.isEmpty)
+    }
+
+    func testSearchProspectsByTag() {
+        _ = app.addProspect(name: "Tagged", email: "tagged@example.com", tags: ["thriller", "mystery"])
+        let results = app.searchProspects(query: "thriller")
+        XCTAssertEqual(results.count, 1)
+    }
+
+    // MARK: - ProspectStatus Transitions
+
+    func testUpdateProspectStatusThrowsForUnknownId() {
+        XCTAssertThrowsError(
+            try app.updateProspectStatus(id: UUID(), status: .contacted)
+        )
+    }
+
+    func testUpdateProspectStatusChangesStatus() throws {
+        let prospect = app.addProspect(name: "Test", email: "test@example.com")
+        XCTAssertEqual(prospect.status, .new)
+
+        try app.updateProspectStatus(id: prospect.id, status: .contacted)
+        let updated = app.prospectDatabase.getProspect(id: prospect.id)
+        XCTAssertEqual(updated?.status, .contacted)
+        XCTAssertNotNil(updated?.lastContactedAt)
+    }
+
+    func testGetProspectsByStatus() throws {
+        let p1 = app.addProspect(name: "P1", email: "p1@x.com")
+        let p2 = app.addProspect(name: "P2", email: "p2@x.com")
+        _ = app.addProspect(name: "P3", email: "p3@x.com")
+
+        try app.updateProspectStatus(id: p1.id, status: .contacted)
+        try app.updateProspectStatus(id: p2.id, status: .replied)
+
+        XCTAssertEqual(app.getProspects(withStatus: .new).count, 1)
+        XCTAssertEqual(app.getProspects(withStatus: .contacted).count, 1)
+        XCTAssertEqual(app.getProspects(withStatus: .replied).count, 1)
+    }
+
+    func testProspectStats() throws {
+        _ = app.addProspect(name: "A", email: "a@x.com")
+        let b = app.addProspect(name: "B", email: "b@x.com")
+        let c = app.addProspect(name: "C", email: "c@x.com")
+        try app.updateProspectStatus(id: b.id, status: .contacted)
+        try app.updateProspectStatus(id: c.id, status: .converted)
+
+        let stats = app.getProspectStats()
+        XCTAssertEqual(stats[.new], 1)
+        XCTAssertEqual(stats[.contacted], 1)
+        XCTAssertEqual(stats[.converted], 1)
+        XCTAssertEqual(stats[.replied], 0)
+    }
+
+    // MARK: - CoworkSession Counters
+
+    func testCoworkSessionStartAndEnd() {
+        XCTAssertNil(app.activeCoworkSession)
+        let session = app.startCoworkSession()
+        XCTAssertNotNil(app.activeCoworkSession)
+        XCTAssertEqual(session.emailsSent, 0)
+        XCTAssertEqual(session.prospectsAdded, 0)
+        XCTAssertEqual(session.prospectsContacted, 0)
+        XCTAssertEqual(session.pagesResearched, 0)
+
+        let ended = app.endCoworkSession()
+        XCTAssertNotNil(ended?.endedAt)
+        XCTAssertNil(app.activeCoworkSession)
+    }
+
+    func testEndCoworkSessionWithNoActiveSessionReturnsNil() {
+        XCTAssertNil(app.endCoworkSession())
+    }
+
+    func testProspectsAddedCounter() {
+        app.startCoworkSession()
+        _ = app.addProspect(name: "New P", email: "n@x.com")
+        _ = app.addProspect(name: "New P2", email: "n2@x.com")
+        XCTAssertEqual(app.activeCoworkSession?.prospectsAdded, 2)
+    }
+
+    func testProspectsContactedCounterOnlyIncrementsOnTrueTransition() throws {
+        app.startCoworkSession()
+        let prospect = app.addProspect(name: "P", email: "p@x.com")
+
+        // Transition new → contacted: should increment
+        try app.updateProspectStatus(id: prospect.id, status: .contacted)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+
+        // contacted → contacted again: should NOT increment
+        try app.updateProspectStatus(id: prospect.id, status: .contacted)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+
+        // contacted → replied (still a contact state): should NOT increment
+        try app.updateProspectStatus(id: prospect.id, status: .replied)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+
+        // replied → declined (not a contact state): counter stays
+        try app.updateProspectStatus(id: prospect.id, status: .declined)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+
+        // declined → meeting (contact state, transitioning from non-contact): should increment
+        try app.updateProspectStatus(id: prospect.id, status: .meeting)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 2)
+    }
+
+    func testCoworkSessionDurationMinutes() {
+        _ = app.startCoworkSession()
+        let ended = app.endCoworkSession()
+        XCTAssertNotNil(ended?.durationMinutes)
+        XCTAssertGreaterThanOrEqual(ended!.durationMinutes!, 0)
+    }
+
+    // MARK: - BrowserService
+
+    func testBrowsedPageStruct() {
+        let page = BrowsedPage(url: "https://example.com", title: "Test", textContent: "Hello World")
+        XCTAssertEqual(page.textContent, "Hello World")
+        XCTAssertEqual(page.url, "https://example.com")
+        XCTAssertEqual(page.title, "Test")
+    }
+
+    func testBrowserHistoryTracking() {
+        XCTAssertTrue(app.getBrowsingHistory().isEmpty)
+        app.browserService.clearHistory()
+        XCTAssertTrue(app.getBrowsingHistory().isEmpty)
+    }
+
+    func testBrowsedPagePlainText() {
+        let page = BrowsedPage(url: "https://test.example.com", title: "Title", textContent: "Plain text, no tags.")
+        XCTAssertFalse(page.textContent.contains("<"))
+        XCTAssertFalse(page.textContent.contains(">"))
+        XCTAssertEqual(page.textContent, "Plain text, no tags.")
+    }
+
+    // MARK: - ProspectStatus Enum
+
+    func testProspectStatusDisplayNames() {
+        XCTAssertEqual(ProspectStatus.new.displayName, "New")
+        XCTAssertEqual(ProspectStatus.contacted.displayName, "Contacted")
+        XCTAssertEqual(ProspectStatus.replied.displayName, "Replied")
+        XCTAssertEqual(ProspectStatus.meeting.displayName, "Meeting Scheduled")
+        XCTAssertEqual(ProspectStatus.declined.displayName, "Declined")
+        XCTAssertEqual(ProspectStatus.converted.displayName, "Converted")
+        XCTAssertEqual(ProspectStatus.allCases.count, 6)
+    }
+
+    // MARK: - GmailDraft Model
+
+    func testGmailDraftInit() {
+        let draft = GmailDraft(
+            to: "agent@example.com",
+            subject: "Query: My Novel",
+            body: "Dear Agent,\n\nI am writing to query..."
+        )
+        XCTAssertEqual(draft.to, "agent@example.com")
+        XCTAssertEqual(draft.subject, "Query: My Novel")
+        XCTAssertNil(draft.inReplyTo)
+    }
+
+    func testGmailDraftWithReply() {
+        let draft = GmailDraft(
+            to: "agent@example.com",
+            subject: "Re: Query",
+            body: "Thank you!",
+            inReplyTo: "thread-abc-123"
+        )
+        XCTAssertEqual(draft.inReplyTo, "thread-abc-123")
+    }
+
+    // MARK: - CoworkError
+
+    func testCoworkErrorDescriptions() {
+        XCTAssertNotNil(CoworkError.gmailNotEnabled.errorDescription)
+        XCTAssertNotNil(CoworkError.invalidOAuthToken.errorDescription)
+        XCTAssertNotNil(CoworkError.prospectNotFound(UUID()).errorDescription)
+        XCTAssertNotNil(CoworkError.browserFetchFailed("timeout").errorDescription)
+        XCTAssertNotNil(CoworkError.networkError("500").errorDescription)
+        XCTAssertNotNil(CoworkError.invalidURL.errorDescription)
+    }
+
+    // MARK: - Gmail Enable/Disable
+
+    func testGmailEnableDisable() {
+        XCTAssertFalse(app.isGmailEnabled)
+        app.enableGmail(oauthToken: "fake-token")
+        XCTAssertTrue(app.isGmailEnabled)
+        app.disableGmail()
+        XCTAssertFalse(app.isGmailEnabled)
+    }
+
+    func testMarkGmailAsReadThrowsWhenDisabled() async {
+        XCTAssertFalse(app.isGmailEnabled)
+        do {
+            try await app.markGmailAsRead(id: "msg-id")
+            XCTFail("Expected CoworkError.gmailNotEnabled to be thrown")
+        } catch CoworkError.gmailNotEnabled {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testListGmailMessagesThrowsWhenDisabled() async {
+        XCTAssertFalse(app.isGmailEnabled)
+        do {
+            _ = try await app.listGmailMessages()
+            XCTFail("Expected CoworkError.gmailNotEnabled to be thrown")
+        } catch CoworkError.gmailNotEnabled {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
- Replace string URL construction with URLComponents in listMessages to
  correctly encode query parameters (& and + chars were previously missed)
- Switch to withThrowingTaskGroup for concurrent message fetching so errors
  propagate instead of being swallowed by try?
- Fix stripHTML closed-range trap: removeSubrange now uses half-open range
  to avoid trapping when closing tag ends at endIndex
- Guard updateProspectStatus counter so prospectsContacted only increments
  on true transitions into a contact state, not repeated sets
- Add markGmailMessageAsRead CLI option (108) and renumber Send Email → 109,
  Research URL → 110, Browsing History → 111
- Validate maxResults input in viewGmailInbox (1–100, rejects invalid)
- Add CoworkModeTests.swift (24 tests) covering CRUD, status transitions,
  session counters, Gmail enable/disable, GmailDraft, and CoworkError

https://claude.ai/code/session_019SQqnzzsffWy8TyeDCf5XE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to mark Gmail messages as read from the CLI interface.

* **Bug Fixes**
  * Fixed prospect contact counter to increment only when transitioning to contact-related statuses.
  * Enhanced Gmail inbox input validation with range checking (1-100) for max results parameter.

* **Tests**
  * Added comprehensive test suite covering prospect database operations, status updates, session management, browser functionality, and Gmail integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->