### PR TITLE
Fix compilation issues from Issue #4: Hashable, editor sync, initial doc, Find & Replace

### DIFF
--- a/Sources/WritersApp/Models/Document.swift
+++ b/Sources/WritersApp/Models/Document.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents a writing document created from a template or from scratch
-public struct Document: Codable, Identifiable {
+public struct Document: Codable, Identifiable, Hashable {
     public let id: UUID
     public var title: String
     public var content: String
@@ -75,7 +75,7 @@ public struct Document: Codable, Identifiable {
 }
 
 /// Metadata for documents
-public struct DocumentMetadata: Codable {
+public struct DocumentMetadata: Codable, Hashable {
     public var created: Date
     public var modified: Date
     public var lastOpened: Date?

--- a/Sources/WritersApp/Views/MetalDashboardViewModel.swift
+++ b/Sources/WritersApp/Views/MetalDashboardViewModel.swift
@@ -81,6 +81,9 @@ public class MetalDashboardViewModel: ObservableObject {
 
     public func loadRecentDocuments() {
         recentDocuments = app.documentManager.getRecentDocuments(limit: 6)
+        if selectedDocument == nil {
+            selectedDocument = recentDocuments.first
+        }
     }
 
     public func loadGoals() {

--- a/Sources/WritersApp/Views/iPadProViews.swift
+++ b/Sources/WritersApp/Views/iPadProViews.swift
@@ -49,6 +49,7 @@ struct AdaptiveLayoutView: View {
             HStack(spacing: 0) {
                 // Document Editor
                 DocumentEditorView(viewModel: viewModel)
+                    .id(viewModel.currentDocumentId)
                     .frame(maxWidth: layout.editorMaxWidth)
 
                 // AI Panel
@@ -172,6 +173,11 @@ struct DocumentEditorView: View {
             EditorStatusBarView(viewModel: viewModel)
         }
         .background(Color(uiColor: .systemBackground))
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if viewModel.showFindReplaceBar {
+                FindReplaceBarView(viewModel: viewModel)
+            }
+        }
         .sheet(isPresented: $viewModel.showWordCountSheet) {
             WordCountDetailView(viewModel: viewModel)
         }
@@ -179,6 +185,57 @@ struct DocumentEditorView: View {
             if let svm = viewModel.spoilerPanelVM {
                 SpoilerManagerView(viewModel: svm)
             }
+        }
+    }
+}
+
+// MARK: - Find & Replace Bar View
+
+/// Inline bar for finding and replacing text in the document
+@available(iOS 16.0, macOS 13.0, *)
+struct FindReplaceBarView: View {
+    @ObservedObject var viewModel: WritersAppViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+
+                TextField("Find", text: $viewModel.findText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+
+                Image(systemName: "arrow.right.arrow.left")
+                    .foregroundColor(.secondary)
+
+                TextField("Replace", text: $viewModel.replaceText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 200)
+
+                Toggle("Aa", isOn: $viewModel.isCaseSensitiveSearch)
+                    .toggleStyle(.button)
+                    .font(.system(size: 13, weight: .medium))
+                    .help("Case Sensitive")
+
+                Button("Replace All") {
+                    viewModel.findAndReplace()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.findText.isEmpty)
+
+                Spacer()
+
+                Button(action: { viewModel.toggleFindReplace() }) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Color(uiColor: .secondarySystemBackground))
+
+            Divider()
         }
     }
 }
@@ -320,6 +377,12 @@ struct EditorToolbarView: View {
                 Label("AI Assistant", systemImage: "sparkles")
             }
             .keyboardShortcut("a", modifiers: [.command, .option])
+
+            // Find & Replace button
+            Button(action: { viewModel.toggleFindReplace() }) {
+                Image(systemName: "magnifyingglass")
+            }
+            .keyboardShortcut("f", modifiers: [.command, .option])
 
             // Focus mode button
             Button(action: { viewModel.toggleFocusMode() }) {
@@ -839,6 +902,13 @@ public class WritersAppViewModel: ObservableObject {
     @Published public var aiResponse: String = ""
     @Published public var showWordCountSheet: Bool = false
     @Published public var showDocumentInfoSheet: Bool = false
+    @Published public var currentDocumentId: UUID? = nil
+
+    // Find & Replace
+    @Published public var showFindReplaceBar: Bool = false
+    @Published public var findText: String = ""
+    @Published public var replaceText: String = ""
+    @Published public var isCaseSensitiveSearch: Bool = false
 
     // Statistics
     @Published public var wordCount: Int = 0
@@ -873,14 +943,22 @@ public class WritersAppViewModel: ObservableObject {
 
     public func initialize() {
         writersApp = WritersApp()
-        updateStatistics()
-        
+
         // Initialize a demo user session for testing database features
         // NOTE: In production, this should use a stable user identifier
         // from authentication/user management system
         let demoUserId = UUID()
         writersApp?.startSession(userId: demoUserId, multitaskingMode: "Split View")
-        
+
+        // Open the most recent document on launch, or create a blank one
+        if let existing = writersApp?.documentManager.getRecentDocuments(limit: 1).first {
+            openDocument(existing)
+        } else {
+            createNewDocument()
+        }
+
+        updateStatistics()
+
         // Load initial data
         loadRecentSuggestions()
         loadToolUsageStats()
@@ -890,8 +968,17 @@ public class WritersAppViewModel: ObservableObject {
 
     public func createNewDocument() {
         currentDocument = writersApp?.createBlankDocument(title: "Untitled", category: .other)
+        currentDocumentId = currentDocument?.id
         currentDocumentTitle = currentDocument?.title ?? "Untitled"
         currentDocumentContent = currentDocument?.content ?? ""
+        updateStatistics()
+    }
+
+    public func openDocument(_ doc: Document) {
+        currentDocument = doc
+        currentDocumentId = doc.id
+        currentDocumentTitle = doc.title
+        currentDocumentContent = doc.content
         updateStatistics()
     }
 
@@ -1103,6 +1190,30 @@ public class WritersAppViewModel: ObservableObject {
         withAnimation {
             isFocusMode.toggle()
         }
+    }
+
+    public func toggleFindReplace() {
+        withAnimation {
+            showFindReplaceBar.toggle()
+        }
+        if !showFindReplaceBar {
+            findText = ""
+            replaceText = ""
+        }
+    }
+
+    public func findAndReplace() {
+        guard !findText.isEmpty else { return }
+        if isCaseSensitiveSearch {
+            currentDocumentContent = currentDocumentContent.replacingOccurrences(of: findText, with: replaceText)
+        } else {
+            currentDocumentContent = currentDocumentContent.replacingOccurrences(
+                of: findText,
+                with: replaceText,
+                options: .caseInsensitive
+            )
+        }
+        updateStatistics()
     }
 
     // MARK: - AI Operations

--- a/Tests/WritersAppTests/WritersAppTests.swift
+++ b/Tests/WritersAppTests/WritersAppTests.swift
@@ -52,6 +52,28 @@ final class WritersAppTests: XCTestCase {
         XCTAssertEqual(document.wordCount, 10)
     }
 
+    func testDocumentHashable() {
+        let doc1 = Document(title: "A", content: "Hello", category: .article)
+        let doc2 = Document(title: "A", content: "Hello", category: .article)
+        // Same id ⇒ same hash
+        let sameId = Document(id: doc1.id, title: "A", content: "Hello", category: .article)
+        XCTAssertEqual(doc1.hashValue, sameId.hashValue)
+        // Documents can be stored in Sets
+        var set = Set<Document>()
+        set.insert(doc1)
+        set.insert(doc2)
+        XCTAssertEqual(set.count, 2)
+        set.insert(sameId)
+        XCTAssertEqual(set.count, 2, "Duplicate id should not increase set size")
+    }
+
+    func testDocumentReadingTimeNeverZero() {
+        let empty = Document(title: "T", content: "", category: .other)
+        XCTAssertGreaterThanOrEqual(empty.readingTime, 1, "Reading time must be at least 1 min")
+        let short = Document(title: "T", content: "Hello", category: .other)
+        XCTAssertGreaterThanOrEqual(short.readingTime, 1)
+    }
+
     func testTemplateSearch() {
         let results = app.templateManager.searchTemplates(query: "novel")
         XCTAssertGreaterThan(results.count, 0, "Should find novel templates")


### PR DESCRIPTION
- Add Hashable conformance to Document and DocumentMetadata so they
  can be used in SwiftUI List selection bindings and Set collections
- Add currentDocumentId (@Published) to WritersAppViewModel and apply
  .id(viewModel.currentDocumentId) to DocumentEditorView so SwiftUI
  force-recreates editor state when the selected document changes
- Set initial document on launch: WritersAppViewModel.initialize()
  now loads the most recent document (or creates a blank one) so the
  editor is never empty on first open
- Set initial selectedDocument in MetalDashboardViewModel.loadRecentDocuments()
  so the dashboard pre-selects the first recent document on load
- Implement Find & Replace with case-sensitive toggle: new
  FindReplaceBarView panel (Cmd+Opt+F), findAndReplace() method, and
  isCaseSensitiveSearch flag on WritersAppViewModel
- Add tests: testDocumentHashable, testDocumentReadingTimeNeverZero

Closes #4

https://claude.ai/code/session_01PiPVjbCiNssUrhXACNXTfh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Find and replace functionality available with keyboard shortcut (⌘⌥F)
  * Case-sensitive search option for precise text replacement
  * Improved document initialization with automatic recent document loading

* **Bug Fixes**
  * Document selection now correctly initializes after recent documents refresh

* **Tests**
  * Added unit tests for document behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->