### PR TITLE
Cowork update: remove transition guard from updateProspectStatus

### DIFF
--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -1588,12 +1588,8 @@ public class WritersApp {
     ///   - status: The new `ProspectStatus` to apply.
     /// - Throws: Any error thrown by `prospectDatabase.updateProspectStatus(id:status:)`.
     public func updateProspectStatus(id: UUID, status: ProspectStatus) throws {
-        let isContactStatus: (ProspectStatus) -> Bool = {
-            $0 == .contacted || $0 == .replied || $0 == .meeting
-        }
-        let previousStatus = prospectDatabase.getProspect(id: id)?.status
         try prospectDatabase.updateProspectStatus(id: id, status: status)
-        if isContactStatus(status) && !(previousStatus.map(isContactStatus) ?? false) {
+        if status == .contacted || status == .replied || status == .meeting {
             activeCoworkSession?.prospectsContacted += 1
         }
     }

--- a/Tests/WritersAppTests/CoworkModeTests.swift
+++ b/Tests/WritersAppTests/CoworkModeTests.swift
@@ -150,29 +150,29 @@ final class CoworkModeTests: XCTestCase {
         XCTAssertEqual(app.activeCoworkSession?.prospectsAdded, 2)
     }
 
-    func testProspectsContactedCounterOnlyIncrementsOnTrueTransition() throws {
+    func testProspectsContactedCounterIncrementsOnEveryContactStatus() throws {
         app.startCoworkSession()
         let prospect = app.addProspect(name: "P", email: "p@x.com")
 
-        // Transition new → contacted: should increment
+        // new → contacted: increments
         try app.updateProspectStatus(id: prospect.id, status: .contacted)
         XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
 
-        // contacted → contacted again: should NOT increment
+        // contacted → contacted again: still increments (new behaviour — no transition guard)
         try app.updateProspectStatus(id: prospect.id, status: .contacted)
-        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 2)
 
-        // contacted → replied (still a contact state): should NOT increment
+        // contacted → replied: increments
         try app.updateProspectStatus(id: prospect.id, status: .replied)
-        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 3)
 
         // replied → declined (not a contact state): counter stays
         try app.updateProspectStatus(id: prospect.id, status: .declined)
-        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 1)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 3)
 
-        // declined → meeting (contact state, transitioning from non-contact): should increment
+        // declined → meeting: increments
         try app.updateProspectStatus(id: prospect.id, status: .meeting)
-        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 2)
+        XCTAssertEqual(app.activeCoworkSession?.prospectsContacted, 4)
     }
 
     func testCoworkSessionDurationMinutes() {

--- a/Tests/WritersAppTests/WritersAppCoworkTests.swift
+++ b/Tests/WritersAppTests/WritersAppCoworkTests.swift
@@ -134,14 +134,14 @@ final class WritersAppCoworkTests: XCTestCase {
             "Setting status to .new must not increment prospectsContacted")
     }
 
-    func testUpdateProspectStatusRejectedDoesNotIncrementContactCounter() throws {
+    func testUpdateProspectStatusDeclinedDoesNotIncrementContactCounter() throws {
         let _ = app.startCoworkSession()
-        let prospect = app.addProspect(name: "Rejected", email: "rej@example.com")
-        try app.updateProspectStatus(id: prospect.id, status: .rejected)
+        let prospect = app.addProspect(name: "Declined", email: "declined@example.com")
+        try app.updateProspectStatus(id: prospect.id, status: .declined)
 
         let ended = app.endCoworkSession()
         XCTAssertEqual(ended?.prospectsContacted, 0,
-            "Setting status to .rejected must not increment prospectsContacted")
+            "Setting status to .declined must not increment prospectsContacted")
     }
 
     // MARK: - ProspectDatabase Directly (unit tests for ProspectDatabase class)


### PR DESCRIPTION
- WritersApp.updateProspectStatus now increments prospectsContacted on
  every contact-status set (.contacted, .replied, .meeting) regardless
  of previous status, removing the old "true transition" guard
- Fix .rejected (non-existent) → .declined in WritersAppCoworkTests
- Update CoworkModeTests to reflect new always-increment behaviour

https://claude.ai/code/session_01B2e3a9LFZjvYTXKFcgTrsb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prospect contact status tracking to properly increment counters when updating to contact-related statuses, ensuring consistent behavior across all status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->