### PR TITLE
Add GitHub Codespaces devcontainer for Swift development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "friendly-outlaw Swift",
+  "image": "swift:6.0",
+  "postCreateCommand": "swift build",
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "sswg.swift-lang"
+      ],
+      "settings": {
+        "swift.path": "/usr/bin"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds .devcontainer/devcontainer.json using swift:6.0 image so the project
can be opened and run interactively via GitHub Codespaces without local Swift installation.

https://claude.ai/code/session_01A2rTmAWN3HUaZrK39T9nPv