### PR TITLE
Add searchGoals to WritingGoalManager, matching IssueManager/KanbanManager API

### DIFF
--- a/Sources/WritersApp/Services/WritingGoalManager.swift
+++ b/Sources/WritersApp/Services/WritingGoalManager.swift
@@ -107,6 +107,17 @@ public class WritingGoalManager {
         return goals.values.filter { $0.type == .daily && $0.isActive }
     }
 
+    /// Searches goals by name or notes
+    public func searchGoals(query: String) -> [WritingGoal] {
+        if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return getAllGoals()
+        }
+        return goals.values.filter { goal in
+            goal.name.localizedCaseInsensitiveContains(query) ||
+            goal.notes.localizedCaseInsensitiveContains(query)
+        }.sorted { $0.startDate > $1.startDate }
+    }
+
     // MARK: - Progress Tracking
 
     /// Records progress toward a goal

--- a/Tests/WritersAppTests/WritingGoalManagerTests.swift
+++ b/Tests/WritersAppTests/WritingGoalManagerTests.swift
@@ -729,6 +729,73 @@ final class WritingGoalManagerTests: XCTestCase {
         }
     }
 
+    // MARK: - Search Tests
+
+    func testSearchGoalsByName() {
+        _ = manager.createGoal(name: "Morning Writing", type: .daily, target: 500)
+        _ = manager.createGoal(name: "Novel Project", type: .project, target: 50000)
+
+        let results = manager.searchGoals(query: "morning")
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.name, "Morning Writing")
+    }
+
+    func testSearchGoalsByNotes() {
+        var goal = manager.createGoal(name: "Daily Goal", type: .daily, target: 500)
+        goal.notes = "Focus on chapter three"
+        manager.updateGoal(goal)
+        _ = manager.createGoal(name: "Weekly Goal", type: .weekly, target: 3000)
+
+        let results = manager.searchGoals(query: "chapter")
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.id, goal.id)
+    }
+
+    func testSearchGoalsCaseInsensitive() {
+        _ = manager.createGoal(name: "NOVEL PROJECT", type: .project, target: 50000)
+
+        let results = manager.searchGoals(query: "novel")
+
+        XCTAssertEqual(results.count, 1)
+    }
+
+    func testSearchGoalsEmptyQueryReturnsAll() {
+        _ = manager.createGoal(name: "Goal 1", type: .daily, target: 500)
+        _ = manager.createGoal(name: "Goal 2", type: .weekly, target: 3000)
+
+        let results = manager.searchGoals(query: "")
+
+        XCTAssertEqual(results.count, 2)
+    }
+
+    func testSearchGoalsWhitespaceQueryReturnsAll() {
+        _ = manager.createGoal(name: "Goal 1", type: .daily, target: 500)
+
+        let results = manager.searchGoals(query: "   ")
+
+        XCTAssertEqual(results.count, 1)
+    }
+
+    func testSearchGoalsNoMatch() {
+        _ = manager.createGoal(name: "Morning Writing", type: .daily, target: 500)
+
+        let results = manager.searchGoals(query: "xyz_no_match")
+
+        XCTAssertEqual(results.count, 0)
+    }
+
+    func testSearchGoalsMatchesMultiple() {
+        _ = manager.createGoal(name: "Daily Writing Goal", type: .daily, target: 500)
+        _ = manager.createGoal(name: "Weekly Writing Goal", type: .weekly, target: 3000)
+        _ = manager.createGoal(name: "Unrelated", type: .project, target: 1000)
+
+        let results = manager.searchGoals(query: "writing")
+
+        XCTAssertEqual(results.count, 2)
+    }
+
     // MARK: - Edge Cases and Negative Tests
 
     func testCreateGoalWithZeroTarget() {


### PR DESCRIPTION
WritingGoalManager was the only manager without a search method. The new
searchGoals(query:) filters by name and notes (case-insensitive) and returns
all goals when the query is blank, consistent with searchIssues and searchTasks.

https://claude.ai/code/session_01WAGyyUd51a9QvHEjdFv7Hp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search writing goals by name or notes with flexible matching
  * Results automatically sorted by most recent start date
  * Empty searches display all available goals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->