### PR TITLE
Add MaxHermes (Minimax) model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,7 +549,7 @@ ExportFormat: markdown, plainText, html
 
 ### AI
 ```swift
-AIModel: claude35Sonnet, claude3Opus, claude3Sonnet, claude3Haiku
+AIModel: claude35Sonnet, claude3Opus, claude3Sonnet, claude3Haiku, maxhermes
 AIAssistanceType: continueWriting, improveText, grammarCheck, styleSuggestions,
                   generateOutline, brainstormIdeas, characterDevelopment, plotSuggestions,
                   dialogueImprovement, descriptionEnhancement, titleGeneration,
@@ -645,7 +645,7 @@ See [MYTHOS.md](MYTHOS.md) for information on extended model capabilities used i
 ```swift
 let config = AIConfiguration(
     apiKey: "sk-ant-...",
-    model: .claude35Sonnet,  // or .claude3Opus, .claude3Sonnet, .claude3Haiku
+    model: .claude35Sonnet,  // or .claude3Opus, .claude3Sonnet, .claude3Haiku, .maxhermes
     maxTokens: 4096,
     temperature: 0.7
 )

--- a/Sources/WritersApp/Models/AIModels.swift
+++ b/Sources/WritersApp/Models/AIModels.swift
@@ -28,6 +28,7 @@ public enum AIModel: String, Codable {
     case claude3Opus = "claude-3-opus-20240229"
     case claude3Sonnet = "claude-3-sonnet-20240229"
     case claude3Haiku = "claude-3-haiku-20240307"
+    case maxhermes = "maxhermes-01"
 
     public var displayName: String {
         switch self {
@@ -35,6 +36,7 @@ public enum AIModel: String, Codable {
         case .claude3Opus: return "Claude 3 Opus"
         case .claude3Sonnet: return "Claude 3 Sonnet"
         case .claude3Haiku: return "Claude 3 Haiku"
+        case .maxhermes: return "MaxHermes"
         }
     }
 }

--- a/Tests/WritersAppTests/AIServiceTests.swift
+++ b/Tests/WritersAppTests/AIServiceTests.swift
@@ -36,6 +36,7 @@ final class AIServiceTests: XCTestCase {
         XCTAssertEqual(AIModel.claude3Opus.rawValue, "claude-3-opus-20240229")
         XCTAssertEqual(AIModel.claude3Sonnet.rawValue, "claude-3-sonnet-20240229")
         XCTAssertEqual(AIModel.claude3Haiku.rawValue, "claude-3-haiku-20240307")
+        XCTAssertEqual(AIModel.maxhermes.rawValue, "maxhermes-01")
     }
 
     func testAIModelDisplayNames() {
@@ -43,6 +44,7 @@ final class AIServiceTests: XCTestCase {
         XCTAssertEqual(AIModel.claude3Opus.displayName, "Claude 3 Opus")
         XCTAssertEqual(AIModel.claude3Sonnet.displayName, "Claude 3 Sonnet")
         XCTAssertEqual(AIModel.claude3Haiku.displayName, "Claude 3 Haiku")
+        XCTAssertEqual(AIModel.maxhermes.displayName, "MaxHermes")
     }
 
     // MARK: - AIService Initialization Tests


### PR DESCRIPTION
## Summary

This PR adds support for Minimax's MaxHermes model to the friendly-outlaw project. MaxHermes is now available as an AIModel option alongside existing Claude models.

## Changes Made

- **AIModels.swift**: Added `maxhermes` case to `AIModel` enum with model ID `maxhermes-01` and display name
- **AIServiceTests.swift**: Added test cases for MaxHermes raw value (`maxhermes-01`) and display name (`MaxHermes`)
- **CLAUDE.md**: Updated documentation to include MaxHermes as a supported AI model

## How It Works

MaxHermes integrates seamlessly with the existing Clother multi-provider support. Users can configure MaxHermes through environment variables or use it directly by specifying `.maxhermes` in AIConfiguration:

```swift
let config = AIConfiguration(
    apiKey: "your-api-key",
    model: .maxhermes,
    maxTokens: 4096,
    temperature: 0.7
)
```

## Test Plan

- Verify MaxHermes appears in the AIModel enum
- Confirm raw value is correctly set to `maxhermes-01`
- Ensure display name renders as `MaxHermes`
- Test with Clother configuration using MiniMax provider

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vvk4RUMpnNLT2YW2ooemRj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MaxHermes as a new AI model option available for selection.

* **Documentation**
  * Updated API reference to reflect support for the newly added MaxHermes model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->