### PR TITLE
chore: update next-env.d.ts for Next.js 16 dev server path

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Updates `next-env.d.ts` to reflect Next.js 16 (Turbopack) generating route types under `.next/dev/types/` during dev mode instead of `.next/types/`
- This file is auto-generated by Next.js on `npm run dev` and should not be manually edited

## Test plan

- [x] Run `npm run dev` and confirm the server starts at http://localhost:3000 without errors

https://claude.ai/code/session_01VYps3NMhdeW9bk6cYK42h6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYps3NMhdeW9bk6cYK42h6)_