### PR TITLE
feat: expose ArchiverService convenience methods on WritersApp facade

### DIFF
--- a/Sources/WritersApp/Services/ArchiverService.swift
+++ b/Sources/WritersApp/Services/ArchiverService.swift
@@ -208,7 +208,7 @@ public class ArchiverService {
                 continue
             }
 
-            var tags = doc.tags ?? []
+            var tags = doc.metadata.tags
             if let aiService = aiService {
                 let prompt = """
                     Generate 3-5 concise, interconnected tags for this writing project:
@@ -288,7 +288,7 @@ public class ArchiverService {
             .filter { doc in
                 doc.title.lowercased().contains(lowerQuery) ||
                 doc.content.lowercased().contains(lowerQuery) ||
-                (doc.tags ?? []).contains { $0.lowercased().contains(lowerQuery) }
+                doc.metadata.tags.contains { $0.lowercased().contains(lowerQuery) }
             }
             .prefix(limit))
 
@@ -330,11 +330,11 @@ public class ArchiverService {
             .filter { $0.id != currentDocumentId }
 
         var scored: [(doc: Document, score: Int)] = []
-        let currentTags = Set(current.tags ?? [])
+        let currentTags = Set(current.metadata.tags)
 
         for doc in archived {
             var score = 0
-            let docTags = Set(doc.tags ?? [])
+            let docTags = Set(doc.metadata.tags)
             score += docTags.intersection(currentTags).count * 10
             let currentTitlePrefix = String(current.title.lowercased().prefix(3))
             if doc.title.lowercased().contains(currentTitlePrefix) {

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -461,11 +461,15 @@ public class WritersApp {
         _ query: String,
         limit: Int = 10
     ) -> (documents: [Document], snapshots: [ArchiveSnapshot], collections: [ArchiveCollection]) {
-        return archiverService?.search(query, limit: limit) ?? ([], [], [])
+        guard let service = archiverService else {
+            return (documents: [], snapshots: [], collections: [])
+        }
+        return service.search(query, limit: limit)
     }
 
     public func suggestRelatedArchived(to documentId: UUID, limit: Int = 5) async -> [Document] {
-        return await archiverService?.suggestRelated(to: documentId, limit: limit) ?? []
+        guard let service = archiverService else { return [] }
+        return await service.suggestRelated(to: documentId, limit: limit)
     }
 
     public func getArchiveStats() -> [String: Any] {

--- a/Sources/WritersApp/WritersApp.swift
+++ b/Sources/WritersApp/WritersApp.swift
@@ -377,6 +377,101 @@ public class WritersApp {
         return hermesService?.getSessionStats(from: session)
     }
 
+    // MARK: - Archiver
+
+    @discardableResult
+    public func createArchiveCollection(
+        name: String,
+        description: String = "",
+        theme: String = "default",
+        tags: [String] = []
+    ) -> ArchiveCollection? {
+        return archiverService?.createCollection(name: name, description: description, theme: theme, tags: tags)
+    }
+
+    public func getArchiveCollection(_ id: UUID) -> ArchiveCollection? {
+        return archiverService?.getCollection(id)
+    }
+
+    public func addDocumentToArchiveCollection(_ documentId: UUID, collectionId: UUID) {
+        archiverService?.addDocumentToCollection(documentId, collectionId: collectionId)
+    }
+
+    public func removeDocumentFromArchiveCollection(_ documentId: UUID, collectionId: UUID) {
+        archiverService?.removeDocumentFromCollection(documentId, collectionId: collectionId)
+    }
+
+    public func listArchiveCollections() -> [ArchiveCollection] {
+        return archiverService?.listCollections() ?? []
+    }
+
+    public func deleteArchiveCollection(_ id: UUID) {
+        archiverService?.deleteCollection(id)
+    }
+
+    @discardableResult
+    public func preserveArchiveMilestone(
+        documentId: UUID,
+        title: String,
+        wordCount: Int = 0,
+        characterCount: Int = 0,
+        sessionCount: Int = 0,
+        daysStreak: Int = 0,
+        summary: String = "",
+        tags: [String] = []
+    ) -> ArchiveSnapshot? {
+        return archiverService?.preserveMilestone(
+            documentId: documentId,
+            title: title,
+            wordCount: wordCount,
+            characterCount: characterCount,
+            sessionCount: sessionCount,
+            daysStreak: daysStreak,
+            summary: summary,
+            tags: tags
+        )
+    }
+
+    public func getArchiveSnapshot(_ id: UUID) -> ArchiveSnapshot? {
+        return archiverService?.getSnapshot(id)
+    }
+
+    public func getArchiveSnapshots(forDocument documentId: UUID) -> [ArchiveSnapshot] {
+        return archiverService?.getSnapshots(forDocument: documentId) ?? []
+    }
+
+    public func listArchiveSnapshots() -> [ArchiveSnapshot] {
+        return archiverService?.listSnapshots() ?? []
+    }
+
+    public func organizeArchiveByTags(
+        _ documentIds: [UUID],
+        context: ArchiverContext = ArchiverContext()
+    ) async throws -> [UUID: [String]] {
+        guard let service = archiverService else { throw AIError.aiNotEnabled }
+        return try await service.organizeByTags(documentIds, context: context)
+    }
+
+    public func summarizeDocumentForArchive(_ documentId: UUID) async throws -> String {
+        guard let service = archiverService else { throw AIError.aiNotEnabled }
+        return try await service.summarizeDocument(documentId)
+    }
+
+    public func searchArchive(
+        _ query: String,
+        limit: Int = 10
+    ) -> (documents: [Document], snapshots: [ArchiveSnapshot], collections: [ArchiveCollection]) {
+        return archiverService?.search(query, limit: limit) ?? ([], [], [])
+    }
+
+    public func suggestRelatedArchived(to documentId: UUID, limit: Int = 5) async -> [Document] {
+        return await archiverService?.suggestRelated(to: documentId, limit: limit) ?? []
+    }
+
+    public func getArchiveStats() -> [String: Any] {
+        return archiverService?.getArchiveStats() ?? [:]
+    }
+
     // MARK: - Settings Management
 
     /// Toggle dark mode on/off

--- a/Tests/WritersAppTests/ArchiverServiceTests.swift
+++ b/Tests/WritersAppTests/ArchiverServiceTests.swift
@@ -193,8 +193,9 @@ final class ArchiverServiceTests: XCTestCase {
     }
 
     func testSearchByTags() {
-        let doc = documentManager.createBlankDocument(title: "Story")
-        doc.tags = ["fantasy", "dragon"]
+        var doc = documentManager.createBlankDocument(title: "Story")
+        doc.metadata.tags = ["fantasy", "dragon"]
+        documentManager.updateDocument(doc)
         let collection = archiver.createCollection(name: "Test")
         archiver.addDocumentToCollection(doc.id, collectionId: collection.id)
 
@@ -226,11 +227,13 @@ final class ArchiverServiceTests: XCTestCase {
     // MARK: - Suggestions Tests
 
     func testSuggestRelated() {
-        let currentDoc = documentManager.createBlankDocument(title: "New Dragon Story")
-        currentDoc.tags = ["fantasy", "dragon"]
+        var currentDoc = documentManager.createBlankDocument(title: "New Dragon Story")
+        currentDoc.metadata.tags = ["fantasy", "dragon"]
+        documentManager.updateDocument(currentDoc)
 
-        let relatedDoc = documentManager.createBlankDocument(title: "Old Dragon Story")
-        relatedDoc.tags = ["fantasy", "dragon"]
+        var relatedDoc = documentManager.createBlankDocument(title: "Old Dragon Story")
+        relatedDoc.metadata.tags = ["fantasy", "dragon"]
+        documentManager.updateDocument(relatedDoc)
 
         let collection = archiver.createCollection(name: "Archive")
         archiver.addDocumentToCollection(relatedDoc.id, collectionId: collection.id)
@@ -246,11 +249,13 @@ final class ArchiverServiceTests: XCTestCase {
     }
 
     func testSuggestRelatedNoResults() {
-        let currentDoc = documentManager.createBlankDocument(title: "Unique Story")
-        currentDoc.tags = ["scifi", "alien"]
+        var currentDoc = documentManager.createBlankDocument(title: "Unique Story")
+        currentDoc.metadata.tags = ["scifi", "alien"]
+        documentManager.updateDocument(currentDoc)
 
-        let archiveDoc = documentManager.createBlankDocument(title: "Fantasy Story")
-        archiveDoc.tags = ["fantasy", "dragon"]
+        var archiveDoc = documentManager.createBlankDocument(title: "Fantasy Story")
+        archiveDoc.metadata.tags = ["fantasy", "dragon"]
+        documentManager.updateDocument(archiveDoc)
 
         let collection = archiver.createCollection(name: "Archive")
         archiver.addDocumentToCollection(archiveDoc.id, collectionId: collection.id)
@@ -265,8 +270,9 @@ final class ArchiverServiceTests: XCTestCase {
     }
 
     func testSuggestRelatedExcludesCurrentDocument() {
-        let doc = documentManager.createBlankDocument(title: "Story")
-        doc.tags = ["fantasy"]
+        var doc = documentManager.createBlankDocument(title: "Story")
+        doc.metadata.tags = ["fantasy"]
+        documentManager.updateDocument(doc)
 
         let collection = archiver.createCollection(name: "Archive")
         archiver.addDocumentToCollection(doc.id, collectionId: collection.id)
@@ -304,8 +310,9 @@ final class ArchiverServiceTests: XCTestCase {
     // MARK: - Organization Tests
 
     func testOrganizeByTagsWithoutAI() {
-        let doc = documentManager.createBlankDocument(title: "Story")
-        doc.tags = ["fantasy", "dragon"]
+        var doc = documentManager.createBlankDocument(title: "Story")
+        doc.metadata.tags = ["fantasy", "dragon"]
+        documentManager.updateDocument(doc)
 
         let expectation = XCTestExpectation(description: "Tags organized")
         Task {


### PR DESCRIPTION
## Summary

- Adds 15 convenience wrapper methods to `WritersApp` for the `ArchiverService` (collections, snapshots, tag organization, summarization, search, suggestions, stats)
- Matches the pattern already used for `HermesService` — callers no longer need to reach into the optional `archiverService` property directly
- Methods return sensible defaults (`[]`, `[:]`, `nil`) when the service is not enabled; async methods throw `AIError.aiNotEnabled`

## Test plan

- [ ] CI Swift build and test suite passes (`swift.yml` workflow)
- [ ] Verify `createArchiveCollection`, `preserveArchiveMilestone`, `searchArchive`, `getArchiveStats` return expected values when AI is enabled
- [ ] Verify sync methods return empty defaults when `archiverService` is nil (AI disabled)
- [ ] Verify `organizeArchiveByTags` and `summarizeDocumentForArchive` throw `AIError.aiNotEnabled` when AI is disabled

https://claude.ai/code/session_01F2vVEsPCvEwR4WrALwwX8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2vVEsPCvEwR4WrALwwX8A)_