### PR TITLE
fix: correct aiExpandText and aiSimplifyText to use proper WritersApp API

### DIFF
--- a/Sources/WritersApp/Views/iPadProViews.swift
+++ b/Sources/WritersApp/Views/iPadProViews.swift
@@ -1287,12 +1287,12 @@ public class WritersAppViewModel: ObservableObject {
         guard let doc = currentDocument else { return }
         Task {
             do {
-                let response = try await writersApp?.generateDocumentTitles(
+                let response = try await writersApp?.getAIAssistance(
                     documentId: doc.id,
-                    context: currentDocumentContent
-                ) ?? []
+                    type: .expandText
+                ) ?? AIResponse(text: "")
                 await MainActor.run {
-                    aiResponse = response.joined(separator: "\n")
+                    aiResponse = response.text
                 }
             } catch {
                 await MainActor.run {
@@ -1306,10 +1306,9 @@ public class WritersAppViewModel: ObservableObject {
         guard let doc = currentDocument else { return }
         Task {
             do {
-                let response = try await writersApp?.getAssistance(
+                let response = try await writersApp?.getAIAssistance(
                     documentId: doc.id,
-                    type: .custom("Simplify the following text to be easier to understand:\n\(currentDocumentContent)"),
-                    context: currentDocumentContent
+                    type: .simplifyText
                 ) ?? AIResponse(text: "")
                 await MainActor.run {
                     aiResponse = response.text


### PR DESCRIPTION
## Summary

- `aiExpandText()` was calling `generateDocumentTitles()` — wrong method with wrong return type (`[String]` instead of `AIResponse`). Fixed to call `getAIAssistance(documentId:type:.expandText)`.
- `aiSimplifyText()` was calling the non-existent `writersApp?.getAssistance()`. Fixed to call `getAIAssistance(documentId:type:.simplifyText)` using the proper enum case instead of a `.custom()` string.

## Test plan

- [ ] Build succeeds (`swift build`)
- [ ] Tap "Expand" in the AI sidebar — triggers text expansion via Claude, response appears in the AI Response section
- [ ] Tap "Simplify" in the AI sidebar — triggers text simplification via Claude, response appears in the AI Response section

https://claude.ai/code/session_01BJooiQEo6W3xeZ97EN3UdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJooiQEo6W3xeZ97EN3UdA)_